### PR TITLE
Refactor access token, env vars, module names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,9 @@
 # See https://github.com/Azure/Azurite?tab=readme-ov-file#connection-strings
 AZURITE_CONNECTION_STRING=""
 BLOB_CONTAINER_NAME=pilot-data
+NOTIFY_API_KEY=""
+NOTIFY_API_KID=""
+NOTIFY_API_URL=""
+NOTIFY_FUNCTION_URL=""
+OAUTH2_TOKEN_URL=""
+PRIVATE_KEY_PATH=""

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@
 *.code-workspace
 !project.code-workspace
 
+.env.local
+.env.development.local
+.env.test.local
+
+*.pem
 # Please, add your custom content below!
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/compose.yml
+++ b/compose.yml
@@ -17,8 +17,8 @@ services:
     depends_on:
       - azurite
     environment:
-      # See https://github.com/Azure/Azurite?tab=readme-ov-file#connection-strings for connection string
       - AZURITE_CONNECTION_STRING=${AZURITE_CONNECTION_STRING}
+      - BLOB_CONTAINER_NAME=${BLOB_CONTAINER_NAME}
 
   # Functions
   process-pilot-data:
@@ -32,7 +32,7 @@ services:
       - ASPNETCORE_URLS=http://*:7071
       - FUNCTIONS_WORKER_RUNTIME=python
       - BLOB_CONTAINER_NAME=${BLOB_CONTAINER_NAME}
-      - NOTIFICATION_FUNCTION_URL=http://localhost:7072/api/notify/message/send
+      - NOTIFY_FUNCTION_URL=${NOTIFY_FUNCTION_URL}
 
     depends_on:
       - azurite
@@ -46,4 +46,8 @@ services:
     environment:
       - AzureWebJobsStorage=UseDevelopmentStorage=true
       - ASPNETCORE_URLS=http://*:7072
-      - NOTIFY_API_URL=https://sandbox.api.service.nhs.uk
+      - NOTIFY_API_URL=${NOTIFY_API_URL}
+      - NOTIFY_API_KEY=${NOTIFY_API_KEY}
+      - NOTIFY_API_KID=${NOTIFY_API_KID}
+      - OAUTH2_TOKEN_URL=${OAUTH2_TOKEN_URL}
+      - PRIVATE_KEY_PATH=${PRIVATE_KEY_PATH}

--- a/compose.yml
+++ b/compose.yml
@@ -46,4 +46,4 @@ services:
     environment:
       - AzureWebJobsStorage=UseDevelopmentStorage=true
       - ASPNETCORE_URLS=http://*:7072
-      - BASE_URL=https://sandbox.api.service.nhs.uk
+      - NOTIFY_API_URL=https://sandbox.api.service.nhs.uk

--- a/src/functions/notify/Dockerfile
+++ b/src/functions/notify/Dockerfile
@@ -7,7 +7,7 @@ ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
     AzureWebJobsFeatureFlags=EnableWorkerIndexing \
     AzureWebJobsStorage=UseDevelopmentStorage=true \
     FUNCTIONS_WORKER_RUNTIME=python \
-    BASE_URL=https://sandbox.api.service.nhs.uk \
+    NOTIFY_API_URL=https://sandbox.api.service.nhs.uk \
     WEBSITES_PORT=8080
 
 

--- a/src/functions/notify/__init__.py
+++ b/src/functions/notify/__init__.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(SCRIPT_DIR))

--- a/src/functions/notify/function_app.py
+++ b/src/functions/notify/function_app.py
@@ -1,14 +1,7 @@
+import azure.functions as func
 import json
 import logging
-import sys
-import os
-
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.dirname(SCRIPT_DIR))
-
-import helper
-
-import azure.functions as func
+import notify.helper as helper
 
 app = func.FunctionApp()
 
@@ -19,7 +12,6 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
     notification_type: str = req.route_params.get("notification_type")
     req_body_bytes: bytes = req.get_body()
     json_body: str = json.loads(req_body_bytes.decode("utf-8"))
-    logging.info(f"JSON body: {json_body}")
 
     if notification_type == "message":
         return helper.send_messages(json_body)

--- a/src/functions/notify/helper.py
+++ b/src/functions/notify/helper.py
@@ -57,7 +57,7 @@ def headers(access_token: str, correlation_id: str) -> dict:
 
 
 def url() -> str:
-    return os.environ["BASE_URL"] + "/comms/v1/messages"
+    return os.environ["NOTIFY_API_URL"] + "/comms/v1/messages"
 
 
 def message_body(routing_plan_id, message_data) -> dict:
@@ -107,7 +107,7 @@ def get_access_token() -> str:
         "client_assertion": jwt,
     }
 
-    response = requests.post(base_url(), data=body, headers=headers)
+    response = requests.post(os.getenv("TOKEN_URL"), data=body, headers=headers)
     access_token = response["access_token"]
 
     return access_token

--- a/src/functions/notify/helper.py
+++ b/src/functions/notify/helper.py
@@ -53,7 +53,7 @@ def headers(access_token: str, correlation_id: str) -> dict:
         "content-type": "application/vnd.api+json",
         "accept": "application/vnd.api+json",
         "x-correlation-id": correlation_id,
-        "authorization": "Bearer " + access_token,
+        # "authorization": "Bearer " + access_token,
     }
 
 
@@ -99,6 +99,9 @@ def reference_uuid(val) -> str:
 
 
 def get_access_token() -> str:
+    if os.getenv("NOTIFY_API_KEY") is None:
+        return "awaiting-token"
+
     jwt: str = generate_auth_jwt()
     headers: dict = {"Content-Type": "application/x-www-form-urlencoded"}
 
@@ -108,7 +111,7 @@ def get_access_token() -> str:
         "client_assertion": jwt,
     }
 
-    response = requests.post(os.getenv("TOKEN_URL"), data=body, headers=headers)
+    response = requests.post(os.getenv("OAUTH2_TOKEN_URL"), data=body, headers=headers)
     access_token = response.json()["access_token"]
 
     return access_token
@@ -127,7 +130,7 @@ def generate_auth_jwt() -> str:
         "sub": api_key,
         "iss": api_key,
         "jti": str(uuid.uuid4()),
-        "aud": os.getenv("TOKEN_URL"),
+        "aud": os.getenv("OAUTH2_TOKEN_URL"),
         "exp": int(time.time()) + 300,  # 5mins in the future
     }
 

--- a/src/functions/notify/helper.py
+++ b/src/functions/notify/helper.py
@@ -1,3 +1,4 @@
+import datetime
 import hashlib
 import jwt
 import logging
@@ -108,18 +109,23 @@ def get_access_token() -> str:
     }
 
     response = requests.post(os.getenv("TOKEN_URL"), data=body, headers=headers)
-    access_token = response["access_token"]
+    access_token = response.json()["access_token"]
 
     return access_token
 
 
 def generate_auth_jwt() -> str:
     algorithm: str = "RS512"
-    headers: dict = {"alg": algorithm, "typ": "JWT", "kid": os.getenv("KID")}
+    headers: dict = {
+        "alg": algorithm,
+        "typ": "JWT",
+        "kid": str(os.getenv("NOTIFY_KID"))
+    }
+    api_key: str = os.getenv("NOTIFY_API_KEY")
 
     payload: dict = {
-        "sub": os.getenv("API_KEY"),
-        "iss": os.getenv("API_KEY"),
+        "sub": api_key,
+        "iss": api_key,
         "jti": str(uuid.uuid4()),
         "aud": os.getenv("TOKEN_URL"),
         "exp": int(time.time()) + 300,  # 5mins in the future
@@ -141,7 +147,10 @@ def generate_jwt(
     expiry_minutes: int = None,
 ) -> str:
     if expiry_minutes:
-        expiry_date = datetime.now(timezone.utc) + timedelta(minutes=expiry_minutes)
+        expiry_date = (
+            datetime.datetime.now(datetime.timezone.utc) +
+            datetime.timedelta(minutes=expiry_minutes)
+        )
         payload["exp"] = expiry_date
 
     return jwt.encode(payload, private_key, algorithm, headers)

--- a/src/functions/notify/local.settings.json
+++ b/src/functions/notify/local.settings.json
@@ -4,6 +4,5 @@
     "FUNCTIONS_WORKER_RUNTIME": "python",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "NOTIFY_URL": "https://sandbox.api.service.nhs.uk"
   }
 }

--- a/src/functions/notify/local.settings.json
+++ b/src/functions/notify/local.settings.json
@@ -4,6 +4,6 @@
     "FUNCTIONS_WORKER_RUNTIME": "python",
     "AzureWebJobsFeatureFlags": "EnableWorkerIndexing",
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "BASE_URL": "https://sandbox.api.service.nhs.uk"
+    "NOTIFY_URL": "https://sandbox.api.service.nhs.uk"
   }
 }

--- a/src/functions/notify/requirements.txt
+++ b/src/functions/notify/requirements.txt
@@ -5,10 +5,10 @@ charset-normalizer==3.4.0
 cryptography==43.0.3
 idna==3.10
 iniconfig==2.0.0
-jwt==1.3.1
 packaging==24.1
 pluggy==1.5.0
 pycparser==2.22
+PyJWT==2.9.0
 pytest==8.3.3
 pytest-mock==3.14.0
 python-dateutil==2.9.0.post0

--- a/src/functions/notify/tests/test_function_app.py
+++ b/src/functions/notify/tests/test_function_app.py
@@ -1,10 +1,10 @@
 import azure.functions as func
-import function_app
+import notify.function_app
 import json
 
 
 def test_main(mocker):
-    mock = mocker.patch("helper.send_messages")
+    mock = mocker.patch("notify.helper.send_messages")
     data = {
         "routing_plan": "breast-screening-pilot",
         "recipients": [
@@ -24,7 +24,7 @@ def test_main(mocker):
         route_params={"notification_type": "message"},
     )
 
-    func_call = function_app.main.build().get_user_function()
+    func_call = notify.function_app.main.build().get_user_function()
     func_call(req)
 
     mock.assert_called_once()

--- a/src/functions/notify/tests/test_helper.py
+++ b/src/functions/notify/tests/test_helper.py
@@ -7,7 +7,8 @@ import uuid
 
 @pytest.fixture
 def setup(monkeypatch):
-    monkeypatch.setenv("BASE_URL", "http://example.com")
+    monkeypatch.setenv("NOTIFY_API_URL", "http://example.com")
+    monkeypatch.setenv("TOKEN_URL", "http://tokens.example.com")
 
 
 def test_send_messages(mocker):

--- a/src/functions/notify/tests/test_helper.py
+++ b/src/functions/notify/tests/test_helper.py
@@ -1,5 +1,5 @@
-import helper
 import json
+import notify.helper as helper
 import pytest
 import requests_mock
 import cryptography.hazmat.primitives.asymmetric.rsa as rsa
@@ -9,12 +9,12 @@ import uuid
 @pytest.fixture
 def setup(monkeypatch):
     monkeypatch.setenv("NOTIFY_API_URL", "http://example.com")
-    monkeypatch.setenv("TOKEN_URL", "http://tokens.example.com")
+    monkeypatch.setenv("OAUTH2_TOKEN_URL", "http://tokens.example.com")
 
 
 def test_send_messages(mocker):
-    mocker.patch("helper.get_access_token", return_value="access_token")
-    send_message_mock = mocker.patch("helper.send_message", return_value="OK")
+    mocker.patch("notify.helper.get_access_token", return_value="access_token")
+    send_message_mock = mocker.patch("notify.helper.send_message", return_value="OK")
     data = {
         "routing_plan": "breast-screening-pilot",
         "recipients": [
@@ -51,11 +51,11 @@ def test_send_messages(mocker):
 
 
 def test_send_messages_with_individual_routing_plans(mocker):
-    mocker.patch("helper.get_access_token", return_value="access_token")
+    mocker.patch("notify.helper.get_access_token", return_value="access_token")
     test_routing_plans = helper.ROUTING_PLANS.copy()
     test_routing_plans["cervical-screening-pilot"] = "c838b13c-f98c-4def-93f0-515d4e4f4ee1"
     test_routing_plans["bowel-cancer-screening-pilot"] = "0b1e3b13c-f98c-4def-93f0-515d4e4f4ee1"
-    routing_plans_mock = mocker.patch("helper.ROUTING_PLANS", test_routing_plans)
+    routing_plans_mock = mocker.patch("notify.helper.ROUTING_PLANS", test_routing_plans)
 
     data = {
         "recipients": [
@@ -65,7 +65,7 @@ def test_send_messages_with_individual_routing_plans(mocker):
         ]
     }
 
-    send_message_mock = mocker.patch("helper.send_message", return_value="OK")
+    send_message_mock = mocker.patch("notify.helper.send_message", return_value="OK")
 
     with requests_mock.Mocker() as rm:
         rm.post(
@@ -183,7 +183,7 @@ def test_get_access_token(monkeypatch, mocker, setup):
     monkeypatch.setenv("NOTIFY_API_KEY", "an_api_key")
     monkeypatch.setenv("NOTIFY_API_KID", "a_kid")
     private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    mocker.patch("helper.get_private_key", return_value=private_key)
+    mocker.patch("notify.helper.get_private_key", return_value=private_key)
 
     with requests_mock.Mocker() as rm:
         rm.post(

--- a/src/functions/notify/tests/test_helper.py
+++ b/src/functions/notify/tests/test_helper.py
@@ -2,6 +2,7 @@ import helper
 import json
 import pytest
 import requests_mock
+import cryptography.hazmat.primitives.asymmetric.rsa as rsa
 import uuid
 
 
@@ -176,3 +177,18 @@ def test_message_body():
     }
 
     assert actual == expected
+
+
+def test_get_access_token(monkeypatch, mocker, setup):
+    monkeypatch.setenv("NOTIFY_API_KEY", "an_api_key")
+    monkeypatch.setenv("NOTIFY_API_KID", "a_kid")
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    mocker.patch("helper.get_private_key", return_value=private_key)
+
+    with requests_mock.Mocker() as rm:
+        rm.post(
+            "http://tokens.example.com/",
+            json={"access_token": "an_access_token"},
+        )
+        access_token = helper.get_access_token()
+        assert access_token == "an_access_token"

--- a/src/functions/process_pilot_data/__init__.py
+++ b/src/functions/process_pilot_data/__init__.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.dirname(SCRIPT_DIR))

--- a/src/functions/process_pilot_data/function_app.py
+++ b/src/functions/process_pilot_data/function_app.py
@@ -1,12 +1,8 @@
 import azure.functions as func
+import process_pilot_data.helper
 import logging
-import sys
 import os
 
-SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.dirname(SCRIPT_DIR))
-
-import helper
 
 BLOB_CONTAINER_NAME = os.getenv("BLOB_CONTAINER_NAME", "pilot-data")
 
@@ -17,8 +13,8 @@ app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
 @app.blob_trigger(
     arg_name="csvblob", path="%BLOB_CONTAINER_NAME%/{name}.csv", connection="AzureWebJobsStorage"
 )
-def process_pilot_data(csvblob: func.InputStream) -> str:
+def process_data(csvblob: func.InputStream) -> str:
     logging.info("Triggering data processor from blob update")
     raw_data = csvblob.read().decode("utf-8").splitlines()
-    result = helper.process_data(raw_data)
+    result = process_pilot_data.helper.process_data(raw_data)
     logging.info(f"Data processor result: {result}")

--- a/src/functions/process_pilot_data/requirements.txt
+++ b/src/functions/process_pilot_data/requirements.txt
@@ -5,10 +5,10 @@ charset-normalizer==3.4.0
 cryptography==43.0.3
 idna==3.10
 iniconfig==2.0.0
-jwt==1.3.1
 packaging==24.1
 pluggy==1.5.0
 pycparser==2.22
+PyJWT==2.9.0
 pytest==8.3.3
 pytest-mock==3.14.0
 python-dateutil==2.9.0.post0

--- a/src/functions/process_pilot_data/tests/test_function_app.py
+++ b/src/functions/process_pilot_data/tests/test_function_app.py
@@ -1,12 +1,12 @@
-import function_app
+import process_pilot_data.function_app
 import io
 
 
 def test_function_app(mocker):
-    mock = mocker.patch("helper.process_data")
+    mock = mocker.patch("process_pilot_data.helper.process_data")
     input_stream = io.BytesIO(b'["0000000000,2000-01-01"]')
 
-    func_call = function_app.process_pilot_data.build().get_user_function()
+    func_call = process_pilot_data.function_app.process_data.build().get_user_function()
     func_call(input_stream)
 
     mock.assert_called_once()

--- a/src/functions/process_pilot_data/tests/test_helper.py
+++ b/src/functions/process_pilot_data/tests/test_helper.py
@@ -1,5 +1,5 @@
-import helper
 import json
+import process_pilot_data.helper as helper
 import pytest
 import requests_mock
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Disables access token lookup for development purposes - we can't access any non-sandbox Notify API endpoints without necessary secrets.
- Adds tests for access token lookup - this code had little coverage.
- Refactors a bunch of environment variables - more descriptive names and more env vars to help configure things.
- Configure docker compose with values from environment
- Refactors module names to use function name as top level module.

This PR addresses a few things but the main intention is to make `docker compose up` and the full test suite work locally while we await Notify API integration details.

<!-- Describe your changes in detail. -->

## Context

Access token lookup is not currently working because we don't have full Notify API integration yet so we are missing an API key and some other information. The test suite has some failing tests because of this.


<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
