### PR TITLE
Use `pytest.skip` to skip end to end test

### DIFF
--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import pytest
 import os
 import subprocess
 
@@ -9,6 +10,12 @@ To run the test with logging output use the following command:
 
 pytest --log-cli-level=INFO tests/test_end_to_end.py
 """
+
+
+@pytest.fixture()
+def setup():
+    if not os.getenv("GITHUB_ACTIONS"):
+        pytest.skip("Skipping end to end test, set GITHUB_ACTIONS env var to run this test")
 
 
 def run_docker_compose():
@@ -83,6 +90,5 @@ async def main():
     logging.info("End to end test completed successfully")
 
 
-def test_end_to_end():
-    if os.getenv("GITHUB_ACTIONS"):
-        asyncio.run(main())
+def test_end_to_end(setup):
+    asyncio.run(main())


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Uses `pytest.skip` in a setup fixture if `GITHUB_ACTIONS` env var is not present when running the test or test suite.
<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
