### PR TITLE
Ensure we perform HMAC comparison using compare_digest

### DIFF
--- a/src/functions/message_status/request_verifier.py
+++ b/src/functions/message_status/request_verifier.py
@@ -19,12 +19,15 @@ def verify_headers(headers: dict) -> bool:
 
 def verify_signature(headers: dict, body: str) -> bool:
     expected_signature = hmac.new(
-        bytes(signature_secret(), 'utf-8'),
-        msg=bytes(body, 'utf-8'),
+        bytes(signature_secret(), 'ASCII'),
+        msg=bytes(body, 'ASCII'),
         digestmod=hashlib.sha256
-    ).hexdigest().upper()
+    ).hexdigest()
 
-    return expected_signature == headers[SIGNATURE_HEADER_NAME]
+    return hmac.compare_digest(
+        expected_signature,
+        headers[SIGNATURE_HEADER_NAME],
+    )
 
 
 def signature_secret() -> str:

--- a/tests/message_status/test_request_verifier.py
+++ b/tests/message_status/test_request_verifier.py
@@ -16,10 +16,10 @@ def test_verify_signature(setup):
     assert not request_verifier.verify_signature(headers, 'body')
 
     signature = hmac.new(
-        bytes('application_id.api_key', 'utf-8'),
-        msg=bytes('body', 'utf-8'),
+        bytes('application_id.api_key', 'ASCII'),
+        msg=bytes('body', 'ASCII'),
         digestmod=hashlib.sha256
-    ).hexdigest().upper()
+    ).hexdigest()
 
     headers[request_verifier.SIGNATURE_HEADER_NAME] = signature
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Amend how we verify HMAC signatures

<!-- Describe your changes in detail. -->

## Context

Digests should be ascii encoded and lowercase (as tper the example in NHS Notify docs)

From the Python HMAC module docs:
**Warning** When comparing the output of `hexdigest()` to an externally supplied digest during a verification routine, it is recommended to use the `compare_digest()` function instead of the `==` operator to reduce the vulnerability to timing attacks.


<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
