### PR TITLE
Lower function host logging levels

### DIFF
--- a/src/functions/notify/host.json
+++ b/src/functions/notify/host.json
@@ -7,10 +7,10 @@
   "logging": {
     "fileLoggingMode": "always",
     "logLevel": {
-      "default": "Information",
+      "default": "Warning",
       "Host.Results": "Error",
-      "Function": "Trace",
-      "Host.Aggregator": "Trace"
+      "Function": "Information",
+      "Host.Aggregator": "Error"
     }
   }
 }

--- a/src/functions/process_pilot_data/host.json
+++ b/src/functions/process_pilot_data/host.json
@@ -7,10 +7,10 @@
   "logging": {
     "fileLoggingMode": "always",
     "logLevel": {
-      "default": "Information",
+      "default": "Warning",
       "Host.Results": "Error",
-      "Function": "Trace",
-      "Host.Aggregator": "Trace"
+      "Function": "Information",
+      "Host.Aggregator": "Error"
     }
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

We don't need trace level logging for functions and peripheral runtime information so reduce logging levels. We might review this in future but keep the noise down to info from functions and warnings from elsewhere.
<!-- Describe your changes in detail. -->

## Context

I think end to end tests are affected by overt logging verbosity. In a production like scenario we would not normally use trace level logging. See failure here https://github.com/NHSDigital/dtos-communication-management/actions/runs/11961025705/job/33347740004 which passed on the PR branch.

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
