### PR TITLE
Add notify batch message integration tests

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -156,6 +156,7 @@ services:
       - DATABASE_NAME=${DATABASE_NAME}
       - DATABASE_PASSWORD=${DATABASE_PASSWORD}
       - DATABASE_USER=${DATABASE_USER}
+      - NOTIFY_API_URL=${NOTIFY_API_URL}
     profiles:
       - test-integration
     depends_on:

--- a/database/create_database.sql
+++ b/database/create_database.sql
@@ -14,7 +14,7 @@ CREATE TABLE IF NOT EXISTS batch_messages (
     nhs_number TEXT NOT NULL,
     recipient_id UUID NOT NULL,
     status batch_message_status DEFAULT 'not_sent',
-    PRIMARY KEY (batch_id, message_reference)
+    PRIMARY KEY (batch_id, message_reference, status)
 );
 
 CREATE TABLE IF NOT EXISTS message_statuses (

--- a/src/shared/datastore.py
+++ b/src/shared/datastore.py
@@ -41,8 +41,10 @@ def create_batch_message_record(batch_message_data: dict) -> bool | list[str, st
         with connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(INSERT_BATCH_MESSAGE, batch_message_data)
-
                 return cur.fetchone()
+
+        conn.commit()
+        conn.close()
     except psycopg2.Error as e:
         logging.error("Error creating batch message record")
         logging.error(f"{type(e).__name__} : {e}")
@@ -57,6 +59,7 @@ def create_message_status_record(message_status_data: dict) -> bool | str:
 
                 return cur.fetchone()[0]
 
+        conn.commit()
         conn.close()
     except psycopg2.Error as e:
         logging.error("Error creating message status record")

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -5,7 +5,8 @@ FROM mcr.microsoft.com/azure-functions/python:4-python3.11
 ENV DATABASE_HOST=${DATABASE_HOST} \
     DATABASE_USER=${DATABASE_USER} \
     DATABASE_PASSWORD=${DATABASE_PASSWORD} \
-    DATABASE_NAME=${DATABASE_NAME}
+    DATABASE_NAME=${DATABASE_NAME} \
+    NOTIFY_API_URL=${NOTIFY_API_URL}
 
 
 COPY --from=root_dir Pipfile /
@@ -14,5 +15,6 @@ RUN pip install pipenv
 RUN pipenv install --system
 RUN pipenv install --dev --system
 
+COPY --from=root_dir /src/functions/notify/ /src/functions/notify/
 COPY --from=shared_dir . /src/shared
 COPY . /tests/integration

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -2,4 +2,5 @@ import os
 import sys
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(SCRIPT_DIR) + "/../src/functions/notify/")
 sys.path.insert(0, os.path.dirname(SCRIPT_DIR) + "/../src/shared/")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,11 @@
+import datastore
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="function")
+def truncate_table():
+    with datastore.connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("TRUNCATE TABLE batch_messages")
+            cur.execute("TRUNCATE TABLE message_statuses")
+            cur.connection.commit()

--- a/tests/integration/test_notifier_saves_batch_message_status_records.py
+++ b/tests/integration/test_notifier_saves_batch_message_status_records.py
@@ -1,0 +1,56 @@
+import datastore
+import dotenv
+import notifier
+import os
+import requests_mock
+import uuid
+import uuid_generator
+
+dotenv.load_dotenv(".env.test")
+
+
+def test_notifier_saves_batch_message_records():
+    """Test database record is saved with correct data"""
+    batch_id = str(uuid.uuid4())
+    routing_plan_id = str(uuid.uuid4())
+    message_data = {
+        "nhs_number": "0000000000",
+        "date_of_birth": "1981-10-07",
+        "appointment_time": "10:00",
+        "appointment_date": "2021-12-01",
+        "appointment_location": "Breast Screening Clinic, 123 High Street, London",
+        "correlation_id": "da0b1495-c7cb-468c-9d81-07dee089d728",
+        "contact_telephone_number": "012345678",
+    }
+    response_json = {"data": {"id": "2WL3qFTEFM0qMY8xjRbt1LIKCzM"}}
+
+    with requests_mock.Mocker() as rm:
+        rm.post(
+            f"{os.getenv('NOTIFY_API_URL')}/comms/v1/messages",
+            status_code=201,
+            json=response_json,
+        )
+
+        notifier.send_message("access_token", routing_plan_id, message_data, batch_id)
+
+    with datastore.connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT batch_id, details, message_reference, nhs_number, status FROM batch_messages")
+            records = cur.fetchall()
+            assert len(records) == 2
+
+            assert records[0] == (
+                batch_id,
+                message_data,
+                uuid_generator.message_reference(message_data),
+                message_data["nhs_number"],
+                "not_sent",
+            )
+
+            assert records[1] == (
+                batch_id,
+                response_json,
+                uuid_generator.message_reference(message_data),
+                message_data["nhs_number"],
+                "sent",
+            )


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adds an integration test which asserts the records saved in `batch_messages` when `notifier.send_message` is called.
<!-- Describe your changes in detail. -->

## Context

We have a gap in our tests which verify that the `notifier.send_message` function also saves `batch_messages` as expected.
<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
