### PR TITLE
feat: Adding in postgresql config for nft and int

### DIFF
--- a/infrastructure/tf-core/environments/integration.tfvars
+++ b/infrastructure/tf-core/environments/integration.tfvars
@@ -212,3 +212,25 @@ storage_accounts = {
     }
   }
 }
+
+postgresql = {
+
+  postgres_sql_admin_group      = "postgresql_commgt_int_uks_admin"
+  backup_retention_days         = 30
+  geo_redundant_backup_enabled  = false
+  public_network_access_enabled = false
+  server_version                = 16
+  zone                          = 1
+
+  # commgt database
+  dbs = {
+    commgt = {
+      storage_tier = "P10"
+      storage_mb   = 32768
+      sku_name     = "GP_Standard_D4s_v3"
+    }
+  }
+
+  # fw_rules = {}
+
+}

--- a/infrastructure/tf-core/environments/nft.tfvars
+++ b/infrastructure/tf-core/environments/nft.tfvars
@@ -212,3 +212,25 @@ storage_accounts = {
     }
   }
 }
+
+postgresql = {
+
+  postgres_sql_admin_group      = "postgresql_commgt_nft_uks_admin"
+  backup_retention_days         = 30
+  geo_redundant_backup_enabled  = false
+  public_network_access_enabled = false
+  server_version                = 16
+  zone                          = 1
+
+  # commgt database
+  dbs = {
+    commgt = {
+      storage_tier = "P10"
+      storage_mb   = 32768
+      sku_name     = "GP_Standard_D4s_v3"
+    }
+  }
+
+  # fw_rules = {}
+
+}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Just adding in the configuration to allow postgresql to run in both the nft and integration (int) environments.  They have both been run in these pipelines: - 

nft: - https://dev.azure.com/nhse-dtos/dtos-communication-management/_build/results?buildId=9039&view=results

int: - https://dev.azure.com/nhse-dtos/dtos-communication-management/_build/results?buildId=9040&view=results

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
