### PR TITLE
remove codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-/infrastructure/ @patrickmoore-nc @josielsouzanordcloud


### PR DESCRIPTION
There was a CODEOWNERS file that specificed only @josielsouzanordcloud and @patrickmoore-nc were allowed to make changes to our infrastructure - this PR removes that, as it is in contradiction with our engineering principles.
