### PR TITLE
Add message status integration tests

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -63,6 +63,7 @@ services:
       context: ./tests/end_to_end/
       additional_contexts:
         root_dir: .
+        shared_dir: ./src/shared/
       dockerfile: Dockerfile
     environment:
       - AZURITE_CONNECTION_STRING=${AZURITE_CONNECTION_STRING}

--- a/src/functions/message_status/function_app.py
+++ b/src/functions/message_status/function_app.py
@@ -1,6 +1,7 @@
 import azure.functions as func
 import json
 import logging
+import message_status_recorder
 import request_verifier
 
 app = func.FunctionApp()
@@ -15,12 +16,14 @@ app = func.FunctionApp()
 def main(req: func.HttpRequest) -> func.HttpResponse:
     req_body: str = req.get_body().decode("utf-8")
 
-    logging.info(json.loads(req_body))
+    logging.info(req_body)
 
     if request_verifier.verify_headers(req.headers) is False:
         status_code = 401
         body = {"status": "error"}
     elif request_verifier.verify_signature(req.headers, req_body):
+        body_dict = json.loads(req_body)
+        message_status_recorder.save_message_statuses(body_dict)
         status_code = 200
         body = {"status": "success"}
     else:

--- a/tests/end_to_end/Dockerfile
+++ b/tests/end_to_end/Dockerfile
@@ -15,4 +15,7 @@ RUN pipenv install --system
 RUN pipenv install --dev --system
 
 COPY . /tests/end_to_end
+COPY --from=root_dir /src/functions/message_status/ /src/functions/message_status/
+COPY --from=shared_dir . /src/shared
+
 RUN rm -f /tests/end_to_end/log/functions/*/*.log

--- a/tests/end_to_end/__init__.py
+++ b/tests/end_to_end/__init__.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+# Import order is important here as we need to load the message status function_app module first.
+sys.path.insert(0, os.path.dirname(SCRIPT_DIR) + "/../src/functions/message_status/")
+sys.path.insert(0, os.path.dirname(SCRIPT_DIR) + "/../src/functions/notify/")
+sys.path.insert(0, os.path.dirname(SCRIPT_DIR) + "/../src/shared/")

--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -1,0 +1,11 @@
+import datastore
+import pytest
+
+
+@pytest.fixture(autouse=True, scope="function")
+def truncate_table():
+    with datastore.connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("TRUNCATE TABLE batch_messages")
+            cur.execute("TRUNCATE TABLE message_statuses")
+            cur.connection.commit()

--- a/tests/end_to_end/test_notify_callback_to_message_status_saved.py
+++ b/tests/end_to_end/test_notify_callback_to_message_status_saved.py
@@ -1,0 +1,104 @@
+import azure.functions as func
+import dotenv
+import function_app
+import hashlib
+import hmac
+import json
+import os
+import psycopg2
+import pytest
+
+ENV_FILE = os.getenv("ENV_FILE", ".env.test")
+
+
+@pytest.fixture()
+def setup(mocker):
+    dotenv.load_dotenv(dotenv_path=ENV_FILE)
+
+
+@pytest.fixture
+def callback_request_body():
+    return {
+        "data": [
+            {
+                "type": "MessageStatus",
+                "attributes": {
+                    "messageId": "2WL3qFTEFM0qMY8xjRbt1LIKCzM",
+                    "messageReference": "1642109b-69eb-447f-8f97-ab70a74f5db4",
+                    "messageStatus": "sending",
+                    "messageStatusDescription": " ",
+                    "channels": [
+                        {
+                            "type": "email",
+                            "channelStatus": "delivered"
+                        }
+                    ],
+                    "timestamp": "2023-11-17T14:27:51.413Z",
+                    "routingPlan": {
+                        "id": "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
+                        "name": "Plan Abc",
+                        "version": "ztoe2qRAM8M8vS0bqajhyEBcvXacrGPp",
+                        "createdDate": "2023-11-17T14:27:51.413Z"
+                    }
+                },
+                "links": {
+                    "message": "https://api.service.nhs.uk/comms/v1/messages/2WL3qFTEFM0qMY8xjRbt1LIKCzM"
+                },
+                "meta": {
+                    "idempotencyKey": "2515ae6b3a08339fba3534f3b17cd57cd573c57d25b25b9aae08e42dc9f0a445" #gitleaks:allow
+                }
+            }
+        ]
+    }
+
+
+def assert_message_status_record_created():
+    connection = psycopg2.connect(
+        dbname=os.environ["DATABASE_NAME"],
+        user=os.environ["DATABASE_USER"],
+        host=os.environ["DATABASE_HOST"],
+        password=os.environ["DATABASE_PASSWORD"]
+    )
+    with connection as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT details, message_id, status FROM message_statuses ORDER BY created_at")
+            records = cur.fetchall()
+
+            assert len(records) == 1
+
+            details, message_id, status = records[0]
+            attributes = details["data"][0]["attributes"]
+
+            assert message_id == "2WL3qFTEFM0qMY8xjRbt1LIKCzM"
+            assert status == "sending"
+            assert attributes["messageReference"] == "1642109b-69eb-447f-8f97-ab70a74f5db4"
+            assert attributes["channels"][0]["type"] == "email"
+            assert attributes["channels"][0]["channelStatus"] == "delivered"
+
+
+def test_notify_callback_to_message_status_saved(monkeypatch, callback_request_body):
+    """Test that a callback request creates database records."""
+    monkeypatch.setenv('APPLICATION_ID', 'application_id')
+    monkeypatch.setenv('OAUTH2_API_KEY', 'api_key')
+    req_body = json.dumps(callback_request_body)
+    signature = hmac.new(
+        bytes('application_id.api_key', 'ASCII'),
+        msg=bytes(req_body, 'ASCII'),
+        digestmod=hashlib.sha256
+    ).hexdigest()
+    headers = {
+        "Content-Type": "application/json",
+        "x-api-key": "api_key",
+        "x-hmac-sha256-signature": signature,
+    }
+    req = func.HttpRequest(
+        method="POST",
+        headers=headers,
+        body=bytes(req_body, "utf-8"),
+        url="/api/notify/message/send",
+        route_params={"notification_type": "message"},
+    )
+
+    func_call = function_app.main.build().get_user_function()
+    assert 200 == func_call(req).status_code
+    assert_message_status_record_created()

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -15,6 +15,7 @@ RUN pip install pipenv
 RUN pipenv install --system
 RUN pipenv install --dev --system
 
+COPY --from=root_dir /src/functions/message_status/ /src/functions/message_status/
 COPY --from=root_dir /src/functions/notify/ /src/functions/notify/
 COPY --from=shared_dir . /src/shared
 COPY . /tests/integration

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -2,5 +2,6 @@ import os
 import sys
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(SCRIPT_DIR) + "/../src/functions/message_status/")
 sys.path.insert(0, os.path.dirname(SCRIPT_DIR) + "/../src/functions/notify/")
 sys.path.insert(0, os.path.dirname(SCRIPT_DIR) + "/../src/shared/")

--- a/tests/integration/test_message_status_recorder_saves_message_statuses.py
+++ b/tests/integration/test_message_status_recorder_saves_message_statuses.py
@@ -1,0 +1,55 @@
+import datastore
+import dotenv
+import message_status_recorder
+
+dotenv.load_dotenv(".env.test")
+
+
+def test_message_status_recorder_saves_message_statuses():
+    """Test message status record is saved with correct data when multiple records are sent."""
+    message_data = {
+        "data": [
+            {
+                "attributes": {
+                    "messageId": "2WL3qFTEFM0qMY8xjRbt1LIKCzM",
+                    "messageReference": "ce845717-67bb-46d7-a33d-2a54db12aeaf",
+                    "messageStatus": "sending",
+                },
+                "meta": {
+                    "idempotencyKey": "4215af6b3a08339fba3534f3b17cf57cf573c55d25b25b9aae08e42dc9f0z886", #gitleaks:allow
+                },
+            },
+            {
+                "attributes": {
+                    "messageId": "2WL3qFTEFM0qMY8xjRbt1LIKCzM",
+                    "messageReference": "ce845717-67bb-46d7-a33d-2a54db12aeaf",
+                    "messageStatus": "delivered",
+                },
+                "meta": {
+                    "idempotencyKey": "2515ae6b3a08339fba3534f3b17cd57cd573c57d25b25b9aae08e42dc9f0a445", #gitleaks:allow
+                },
+            },
+        ]
+    }
+
+    message_status_recorder.save_message_statuses(message_data)
+
+    with datastore.connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT idempotency_key, message_id, message_reference, status FROM message_statuses")
+            records = cur.fetchall()
+            assert len(records) == 2
+
+            assert records[0] == (
+                message_data["data"][0]["meta"]["idempotencyKey"],
+                message_data["data"][0]["attributes"]["messageId"],
+                message_data["data"][0]["attributes"]["messageReference"],
+                message_data["data"][0]["attributes"]["messageStatus"],
+            )
+
+            assert records[1] == (
+                message_data["data"][1]["meta"]["idempotencyKey"],
+                message_data["data"][1]["attributes"]["messageId"],
+                message_data["data"][1]["attributes"]["messageReference"],
+                message_data["data"][1]["attributes"]["messageStatus"],
+            )

--- a/tests/unit/message_status/test_function_app.py
+++ b/tests/unit/message_status/test_function_app.py
@@ -43,14 +43,14 @@ def create_http_request(payload):
 
 
 def test_main_logs_payload(mocker, payload):
-    """Test that the payload is logged when the main function is called."""
+    """Test that the request body is logged when the main function is called."""
     mock_log = mocker.patch("logging.info")
     request = create_http_request(payload)
 
     func_call = function_app.main.build().get_user_function()
     func_call(request)
 
-    mock_log.assert_called_once_with(payload)
+    mock_log.assert_called_once_with(json.dumps(payload))
 
 
 def test_main_verify_signature_success(mocker, payload):
@@ -58,6 +58,7 @@ def test_main_verify_signature_success(mocker, payload):
     mocker.patch("json.loads", return_value=payload)
     mocker.patch("request_verifier.verify_headers", return_value=True)
     mocker.patch("request_verifier.verify_signature", return_value=True)
+    mocker.patch("message_status_recorder.save_message_statuses")
 
     request = create_http_request(payload)
     func_call = function_app.main.build().get_user_function()


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adds integration and end to end tests emulating how we receiving callbacks from NHS Notify and saving the request body to the database.
<!-- Describe your changes in detail. -->

## Context

We have a function which is triggered by http requests from NHS Notify and receives a payload containing useful information about message delivery status.
<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
