### PR TITLE
Remove env token caching

### DIFF
--- a/src/functions/notify/notifier.py
+++ b/src/functions/notify/notifier.py
@@ -9,9 +9,6 @@ import uuid_generator
 
 
 def send_messages(data: dict) -> str:
-    if os.getenv("EXAMPLE_KEYVAULT_SECRET"):
-        logging.info(f"Key Vault secret: {os.getenv('EXAMPLE_KEYVAULT_SECRET')}")
-
     responses: list = []
     routing_plan_id: str = None
     batch_id = uuid_generator.reference_uuid(json.dumps(data))

--- a/src/shared/datastore.py
+++ b/src/shared/datastore.py
@@ -85,9 +85,13 @@ def connection():
 
 
 def fetch_database_password():
+    if "DATABASE_PASSWORD" in os.environ:
+        return os.environ["DATABASE_PASSWORD"]
+
     start = time.time()
     credential = DefaultAzureCredential()
     token = credential.get_token(AZURE_AAD_URL).token
     end = time.time()
     logging.info(f"Fetched database password in {(end - start)}s")
+
     return token

--- a/src/shared/datastore.py
+++ b/src/shared/datastore.py
@@ -1,12 +1,11 @@
+from azure.identity import DefaultAzureCredential
 import logging
 import os
 import psycopg2
 import time
 
-from azure.identity import DefaultAzureCredential
 
 AZURE_AAD_URL = "https://ossrdbms-aad.database.windows.net"
-TOKEN_EXPIRY = 86400
 
 INSERT_BATCH_MESSAGE = """
     INSERT INTO batch_messages (
@@ -73,17 +72,22 @@ def create_message_status_record(message_status_data: dict) -> bool | str:
 
 
 def connection():
-    return psycopg2.connect(
+    start = time.time()
+    conn = psycopg2.connect(
         dbname=os.environ["DATABASE_NAME"],
         user=os.environ["DATABASE_USER"],
         host=os.environ["DATABASE_HOST"],
         password=fetch_database_password(),
     )
+    end = time.time()
+    logging.info(f"Connected to database in {(end - start)}s")
+    return conn
 
 
 def fetch_database_password():
-    if float(os.getenv("DATABASE_PASSWORD_EXPIRES", "0")) > time.time():
-        os.environ["DATABASE_PASSWORD"] = DefaultAzureCredential().get_token(AZURE_AAD_URL).token
-        os.environ["DATABASE_PASSWORD_EXPIRES"] = str(time.time() + TOKEN_EXPIRY)
-
-    return os.getenv("DATABASE_PASSWORD")
+    start = time.time()
+    credential = DefaultAzureCredential()
+    token = credential.get_token(AZURE_AAD_URL).token
+    end = time.time()
+    logging.info(f"Fetched database password in {(end - start)}s")
+    return token

--- a/tests/unit/shared/test_datastore.py
+++ b/tests/unit/shared/test_datastore.py
@@ -70,22 +70,19 @@ def test_create_message_status_record_with_error(mock_cursor):
     mock_cursor.fetchone.assert_not_called()
 
 
-def test_fetch_database_password_before_expiry(monkeypatch):
+def test_fetch_database_password_from_env(monkeypatch):
     """Test the fetching of the database password from the environment."""
-    monkeypatch.setenv("DATABASE_PASSWORD_EXPIRES", str(time.time() - 3600))
     monkeypatch.setenv("DATABASE_PASSWORD", "test_password")
 
     assert datastore.fetch_database_password() == "test_password"
 
 
-def test_fetch_database_password_after_expiry(monkeypatch, mocker):
+def test_fetch_database_password_from_credential(monkeypatch, mocker):
     """Test the fetching of the database password from the environment."""
-    monkeypatch.setenv("DATABASE_PASSWORD_EXPIRES", str(time.time() + 3600))
-    monkeypatch.setenv("DATABASE_PASSWORD", "old_password")
     mock_token = mocker.MagicMock()
-    mock_token.token = "new_password"
+    mock_token.token = "token_password"
     mock_credential = mocker.MagicMock()
     mock_credential.get_token.return_value = mock_token
     mocker.patch("datastore.DefaultAzureCredential", return_value=mock_credential)
 
-    assert datastore.fetch_database_password() == "new_password"
+    assert datastore.fetch_database_password() == "token_password"


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Remove env-level token caching. This won't work.
<!-- Describe your changes in detail. -->

## Context

We know from Microsoft documentation that obtaining a MI credential token as we connect to the database is not advisable for production and that token caching is necessary. There's also anecdotal evidence of the token issuing endpoint failing to respond.
We tried to mitigate this by caching the token in the env, but this does not work well with a function app lifecycle.

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
