### PR TITLE
Take first 3 chars from filename regardless of whitespace

### DIFF
--- a/src/functions/process_pilot_data/pilot_bso_details.py
+++ b/src/functions/process_pilot_data/pilot_bso_details.py
@@ -17,7 +17,7 @@ SERVICES = {
 # Expectd file name: XXX NHS App Pilot 002 SPRPT
 # Where XXX is the code
 def code_from_filename(filename: str) -> str:
-    return filename.split(" ")[0].upper()
+    return filename[0:3].upper()
 
 
 def contact_telephone_number(code: str) -> str:


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Use first 3 chars of filename to deduce BSO code. This is slightly more robust than splitting on whitespace.
<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
