### PR TITLE
Fetch the db password from credentials if the env var is empty

### DIFF
--- a/src/shared/datastore.py
+++ b/src/shared/datastore.py
@@ -85,7 +85,7 @@ def connection():
 
 
 def fetch_database_password():
-    if "DATABASE_PASSWORD" in os.environ:
+    if bool(os.getenv("DATABASE_PASSWORD")):
         logging.info("Fetched database password from environment variable")
         return os.environ["DATABASE_PASSWORD"]
 

--- a/tests/unit/shared/test_datastore.py
+++ b/tests/unit/shared/test_datastore.py
@@ -79,6 +79,7 @@ def test_fetch_database_password_from_env(monkeypatch):
 
 def test_fetch_database_password_from_credential(monkeypatch, mocker):
     """Test the fetching of the database password from the environment."""
+    monkeypatch.setenv("DATABASE_PASSWORD", "")
     mock_token = mocker.MagicMock()
     mock_token.token = "token_password"
     mock_credential = mocker.MagicMock()


### PR DESCRIPTION


<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This covers off a side-effect of how we containerise the functions where the `DATABASE_PASSWORD` env var is defaulted to an empty string. 
In this case we should attempt to fetch from the credential endpoint. 
This reflects the default state of a deployed function app on Azure, ie the env var is present but empty.

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
