### PR TITLE
fix: VNet peering manual dependency for private services

### DIFF
--- a/infrastructure/tf-core/key_vault.tf
+++ b/infrastructure/tf-core/key_vault.tf
@@ -29,5 +29,10 @@ module "key_vault" {
     private_service_connection_is_manual = var.features.private_service_connection_is_manual
   } : null
 
+  depends_on = [
+    module.peering_spoke_hub,
+    module.peering_hub_spoke
+  ]
+
   tags = var.tags
 }

--- a/infrastructure/tf-core/postgresql.tf
+++ b/infrastructure/tf-core/postgresql.tf
@@ -44,5 +44,10 @@ module "postgresql_flexible_db" {
     }
   }
 
+  depends_on = [
+    module.peering_spoke_hub,
+    module.peering_hub_spoke
+  ]
+
   tags = var.tags
 }

--- a/infrastructure/tf-core/storage.tf
+++ b/infrastructure/tf-core/storage.tf
@@ -29,6 +29,11 @@ module "storage" {
     private_service_connection_is_manual = var.features.private_service_connection_is_manual
   } : null
 
+  depends_on = [
+    module.peering_spoke_hub,
+    module.peering_hub_spoke
+  ]
+
   tags = var.tags
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This will prevent an issue encountered while building Production environment, where public access to a resource is removed before the VNet peering with the Hub has been established in both directions - confounding further attempts to run `terraform plan`. Effectively a situation could arise, depending on the resource creation order, in which the ADO Agent in the Managed DevOps Pool subnet becomes isolated from Azure resources which it has just created.

Prior to this fix, recovering from this scenario - via manual creation then `terraform import` of the VNet peering - was very difficult indeed given the private nature even of the Terraform state Storage Accounts.

## Testing

Successfully deployed Production tf-core state: https://dev.azure.com/nhse-dtos/dtos-communication-management/_build/results?buildId=10080&view=results

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
