### PR TITLE
Restrict Notify function http methods

### DIFF
--- a/src/functions/notify/function_app.py
+++ b/src/functions/notify/function_app.py
@@ -7,12 +7,14 @@ app = func.FunctionApp()
 
 
 @app.function_name(name="Notify")
-@app.route(route="notify/{notification_type}/send", auth_level=func.AuthLevel.ANONYMOUS)
+@app.route(
+    route="notify/message/send",
+    auth_level=func.AuthLevel.ANONYMOUS,
+    methods=[func.HttpMethod.POST],
+)
 def main(req: func.HttpRequest) -> func.HttpResponse:
     logging.info("Notify HTTP trigger function. Processing batch notification.")
-    notification_type: str = req.route_params.get("notification_type")
     req_body_bytes: bytes = req.get_body()
     json_body: str = json.loads(req_body_bytes.decode("utf-8"))
 
-    if notification_type == "message":
-        return notifier.send_messages(json_body)
+    return notifier.send_messages(json_body)

--- a/tests/unit/notify/test_function_app.py
+++ b/tests/unit/notify/test_function_app.py
@@ -19,7 +19,6 @@ def test_main_calls_notifier_with_correct_data(mocker):
         method="POST",
         body=json.dumps(input_data).encode("utf-8"),
         url="/api/notify/message/send",
-        route_params={"notification_type": "message"},
     )
 
     func_call = function_app.main.build().get_user_function()


### PR DESCRIPTION
## Description

- Restrict function http trigger method to POST
- Remove the dynamic portion of the function trigger path, we don't use it.
<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
