### PR TITLE
Move coverage to its own step

### DIFF
--- a/.github/workflows/stage-2-test.yaml
+++ b/.github/workflows/stage-2-test.yaml
@@ -15,20 +15,8 @@ on:
         description: "Build epoch, set by the CI/CD pipeline workflow"
         required: true
         type: string
-      nodejs_version:
-        description: "Node.js version, set by the CI/CD pipeline workflow"
-        required: true
-        type: string
       python_version:
         description: "Python version, set by the CI/CD pipeline workflow"
-        required: true
-        type: string
-      terraform_version:
-        description: "Terraform version, set by the CI/CD pipeline workflow"
-        required: true
-        type: string
-      version:
-        description: "Version of the software, set by the CI/CD pipeline workflow"
         required: true
         type: string
 
@@ -48,19 +36,6 @@ jobs:
           source venv/bin/activate
           python -m pip install --upgrade pip
 
-  test-lint:
-    name: "Linting"
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Run linting"
-        run: |
-          make test-lint
-      - name: "Save the linting result"
-        run: |
-          echo "Nothing to save"
   test-unit:
     name: "Unit tests"
     needs: set-up-dependencies
@@ -77,24 +52,17 @@ jobs:
 
       - name: "Run unit test suite"
         run: |
-          ./test-unit.sh
-  test-pacts:
-    name: "Contract tests"
-    needs: set-up-dependencies
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v4
+          pytest --cov=src --cov-append
 
-      - name: "Install dependencies"
-        run: |
-          pip install pipenv
-          pipenv install --dev --system
+      - name: "Check coverage file"
+        run: ls -la
 
-      - name: "Run contract test suite"
-        run: |
-          ./test-pacts.sh
+      - name: "Upload coverage data"
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-unit
+          path: .coverage
+
   test-integration:
     name: "Integration tests"
     needs: set-up-dependencies
@@ -111,48 +79,53 @@ jobs:
 
       - name: "Run integration test suite"
         run: |
-          ./test-integration.sh
-  test-end-to-end:
-    name: "End-to-end tests"
-    needs: set-up-dependencies
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v4
-      - name: "Run end to end test suite"
-        run: |
-          ./test-end-to-end.sh
+          pytest --cov=src --cov-append
+
+      - name: "Check coverage file"
+        run: ls -la
+
+      - name: "Upload coverage data"
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-integration
+          path: .coverage
+
   test-coverage:
     name: "Test coverage"
-    needs: [test-unit]
+    needs: [test-unit, test-integration]
     runs-on: ubuntu-latest
-    timeout-minutes: 5
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v4
-      - name: "Run test coverage check"
-        run: |
-          ./test-coverage.sh
-      - name: "Save the coverage check result"
-        run: |
-          echo "Nothing to save"
-  perform-static-analysis:
-    name: "Perform static analysis"
-    needs: [test-unit]
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    timeout-minutes: 5
-    steps:
-      - name: "Checkout code"
-        uses: actions/checkout@v4
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v4
         with:
-          fetch-depth: 0 # Full history is needed to improving relevancy of reporting
-      - name: "Perform static analysis"
-        uses: ./.github/actions/perform-static-analysis
+          python-version: "3.11"
+
+      - name: "Install dependencies"
+        run: |
+          pip install pipenv
+          pipenv install --dev --system
+
+      - name: "Download unit test coverage artifact"
+        uses: actions/download-artifact@v3
         with:
-          sonar_organisation_key: "${{ vars.SONAR_ORGANISATION_KEY }}"
-          sonar_project_key: "${{ vars.SONAR_PROJECT_KEY }}"
-          sonar_token: "${{ secrets.SONAR_TOKEN }}"
+          name: coverage-unit
+          path: coverage-data/unit
+
+      - name: "Download integration test coverage artifact"
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage-integration
+          path: coverage-data/integration
+
+      - name: "Combine coverage data"
+        run: |
+          cp coverage-data/unit/.coverage .coverage.unit
+          cp coverage-data/integration/.coverage .coverage.integration
+          coverage combine .coverage.unit .coverage.integration
+
+      - name: "Generate coverage report"
+        run: |
+          coverage report

--- a/Pipfile
+++ b/Pipfile
@@ -54,6 +54,7 @@ typer = "==0.12.5"
 uvicorn = "==0.32.0"
 yarl = "==1.17.1"
 pytest-cov = "*"
+coverage = "*"
 
 [requires]
 python_version = "3.11"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d126d4b439ec5ca4834a52ed049eb1b8d1be03bfab6ba51774119a6d3907461f"
+            "sha256": "1070e662eadc8e53a4e70cbabe6f20b945417e9fc4ad6d79a8299a5882a21904"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -532,9 +532,6 @@
             "version": "==2.23.4"
         },
         "pyjwt": {
-            "extras": [
-                "crypto"
-            ],
             "hashes": [
                 "sha256:3b02fb0f44517787776cf48f2ae25d8e14f300e6d7545a4315cee571a415e850",
                 "sha256:7e1e5b56cc735432a7369cbfa0efe50fa113ebecdc04ae6922deba8b84582d0c"
@@ -549,7 +546,7 @@
                 "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==2.9.0.post0"
         },
         "python-dotenv": {
@@ -585,7 +582,7 @@
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
         },
         "tqdm": {
@@ -907,6 +904,7 @@
                 "sha256:fd1213c86e48dfdc5a0cc676551db467495a95a662d2396ecd58e719191446e1",
                 "sha256:ff74026a461eb0660366fb01c650c1d00f833a086b336bdad7ab00cc952072b3"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.9'",
             "version": "==7.6.9"
         },
@@ -1445,7 +1443,7 @@
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
             "index": "pypi",
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
             "version": "==1.16.0"
         },
         "sniffio": {

--- a/test-coverage.sh
+++ b/test-coverage.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-echo 'TODO: Implement test coverage script'
+coverage combine
+coverage report

--- a/test-end-to-end.sh
+++ b/test-end-to-end.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-docker compose --env-file .env.test --profile test-end-to-end run --build --quiet-pull end-to-end-tests pytest /tests/end_to_end
+docker compose --env-file .env.test --profile test-end-to-end run --build --quiet-pull end-to-end-tests pytest --cov=src --cov-append /tests/end_to_end
 test_exit_code=$?
 docker compose --env-file .env.test --profile test-end-to-end down --volumes --remove-orphans
 exit $test_exit_code

--- a/test-integration.sh
+++ b/test-integration.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-docker compose --env-file .env.test --profile test-integration run --build integration-tests pytest -v /tests/integration
+docker compose --env-file .env.test --profile test-integration run --build integration-tests pytest -v --cov=src --cov-append /tests/integration
 test_exit_code=$?
 docker compose --env-file .env.test --profile test-integration down db --volumes
 exit $test_exit_code

--- a/test-pacts.sh
+++ b/test-pacts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-pytest -W ignore::PendingDeprecationWarning -vv tests/pacts || {
+pytest -W ignore::PendingDeprecationWarning -vv --cov=src --cov-append tests/pacts || {
     echo "Tests failed in tests/pacts"
     exit 1
 }

--- a/test-unit.sh
+++ b/test-unit.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-pytest --cov=src -vv tests/unit || {
+pytest -v --cov=src --cov-append tests/unit || {
     echo "Tests failed in tests/unit"
     exit 1
 }


### PR DESCRIPTION
Instead of running coverage reports in the unit test job, have its own workflow step actually work

Also has the unusual side effect of making the unit test output nicer (the pytest-cov option that we were using previously must have interfered!)