### PR TITLE
fix: Enhance ACR copy/retag pipeline to publish to Preprod and Prod

### DIFF
--- a/.azuredevops/pipelines/acr-image-retag.yaml
+++ b/.azuredevops/pipelines/acr-image-retag.yaml
@@ -4,6 +4,14 @@ name: $(Build.SourceBranchName)-$(Date:yyyyMMdd)_$(Rev:r)
 trigger: none
 pr: none
 
+resources:
+  repositories:
+    - repository: dtos-devops-templates
+      type: github
+      name: NHSDigital/dtos-devops-templates
+      ref: fa58dc978491f04e1efab73cbf8e2228a351bf81
+      endpoint: NHSDigital
+
 parameters:
   - name: sourceRegistry
     displayName: Source Container Registry
@@ -59,65 +67,6 @@ stages:
       SELECT_IMAGE_TAG: ${{ parameters.selectImageTag }}
       ADD_IMAGE_TAG: ${{ parameters.addImageTag }}
     steps:
-    - checkout: none
-    - task: AzureCLI@2
-      name: tag_integration
-      displayName: Publish $(SELECT_IMAGE_TAG) images to ${{ parameters.addImageTag }}
-      inputs:
-        azureSubscription: sc-communication-management-prod
-        addSpnToEnvironment: true
-        failOnStandardError: false
-        scriptType: bash
-        scriptLocation: inlineScript
-        inlineScript: |
-          # Prerequisite: A DNS A record for the chosen Dev ACR must exist in the Prod privatelink.azurecr.io zone, resolving to the public IP for that ACR
-          set -eo pipefail
-          declare -a pids
-
-          wait_for_completion() {
-            # acr tasks are backgrounded for parallelism
-            local -n arr=$1
-            for pid in "${arr[@]}"; do
-              wait ${pid}
-            done
-          }
-
-          echo "##[debug] Authenticating with container registry ${SRC_REGISTRY}..."
-          az acr login --name ${SRC_REGISTRY}
-          # az acr check-health --name ${SRC_REGISTRY} --yes
-
-          if [[ "${SRC_REGISTRY}" == ${DEST_REGISTRY} ]]; then
-            src_reg_prefix="${SRC_REGISTRY}.azurecr.io/" # omitted when the source registry is in a different subscription
-          else
-            [[ "${SRC_REGISTRY}" =~ dev ]] && cmdopt_sub="--subscription ${TF_VAR_HUB_SUBSCRIPTION_ID}"
-            source_registry_id=$(az acr show --name ${SRC_REGISTRY} ${cmdopt_sub} --query id --output tsv)
-            cmdopt_reg="--registry ${source_registry_id}" # needed when the source registry is in a different subscription
-            echo "##[debug] Authenticating with container registry ${DEST_REGISTRY}..."
-            az acr login --name ${DEST_REGISTRY}
-            # az acr check-health --name ${DEST_REGISTRY} --yes
-          fi
-
-          [[ "${DEST_REGISTRY}" =~ dev ]] && az account set -s ${TF_VAR_HUB_SUBSCRIPTION_ID}
-          repos=$(az acr repository list --name ${SRC_REGISTRY} --output tsv)
-
-          for repo in ${repos}; do
-            echo "##[debug] Importing ${repo}:${SELECT_IMAGE_TAG}..."
-            az acr import --name ${DEST_REGISTRY} --source ${src_reg_prefix}${repo}:${SELECT_IMAGE_TAG} --image ${repo}:${ADD_IMAGE_TAG} ${cmdopt_reg} --force &
-            pids+=($!)
-          done
-          wait_for_completion pids
-
-          if [[ "${SRC_REGISTRY}" != ${DEST_REGISTRY} ]]; then
-            # To minimise data transfers, use only the destination acr to add other relevant tags taken from the source registry (PR ref, commit hash)
-            pids=()
-            for repo in ${repos}; do
-              image_sha=$(az acr repository show --name ${SRC_REGISTRY} --image ${repo}:${SELECT_IMAGE_TAG} --query digest --output tsv)
-              for tag in $(az acr repository show --name ${SRC_REGISTRY} --image ${repo}@${image_sha} --query "tags" --output tsv | grep -E '^(pr[0-9]+|[a-f0-9]{7})$'); do
-                echo "##[debug] Adding tag ${repo}:${tag}..."
-                az acr import --name ${DEST_REGISTRY} --source ${DEST_REGISTRY}.azurecr.io/${repo}:${ADD_IMAGE_TAG} --image ${repo}:${tag} --force &
-                pids+=($!)
-              done
-            done
-            wait_for_completion pids
-          fi
-
+      - template: .azuredevops/templates/steps/acr-import-retag.yaml@dtos-devops-templates
+        parameters:
+          serviceConnection: sc-communication-management-prod

--- a/.azuredevops/pipelines/acr-image-retag.yaml
+++ b/.azuredevops/pipelines/acr-image-retag.yaml
@@ -6,8 +6,11 @@ pr: none
 
 parameters:
   - name: sourceRegistry
-    displayName: Source Registry
+    displayName: Source Container Registry
     type: string
+    values:
+      - acrukshubdevcommgt
+      - acrukshubprodcommgt
     default: acrukshubdevcommgt
 
   - name: selectImageTag
@@ -16,19 +19,27 @@ parameters:
     values:
       - development
       - nft
+      - integration
+      - preprod
     default: development
 
   - name: destRegistry
-    displayName: Destination Registry
-    type: string
-    default: acrukshubdevcommgt
-
-  - name: addImageTag
-    displayName: Additional Image Tag
+    displayName: Destination Container Registry
     type: string
     values:
-      - integration
+      - acrukshubdevcommgt
+      - acrukshubprodcommgt
+    default: acrukshubprodcommgt
+
+  - name: addImageTag
+    displayName: Target Image Tag
+    type: string
+    values:
+      - development
       - nft
+      - integration
+      - preprod
+      - production
     default: integration
 
 variables:
@@ -40,33 +51,45 @@ stages:
   jobs:
   - job: re_tag
     pool:
-      vmImage: ubuntu-latest
-    displayName: Update Docker images with new tag
+      # vmImage: ubuntu-latest
+      name: private-pool-prod-uks
+    displayName: Update/copy Docker images with new tag
     steps:
     - task: AzureCLI@2
       name: tag_integration
-      displayName: Update Docker images with new tag
+      displayName: Publish ${{ parameters.selectImageTag }} images to ${{ parameters.addImageTag }}
       inputs:
-        azureSubscription: sc-communication-management-dev
+        azureSubscription: sc-communication-management-prod
         addSpnToEnvironment: true
-        failOnStandardError: true
+        failOnStandardError: false
         scriptType: bash
         scriptLocation: inlineScript
         inlineScript: |
-          az acr login -n ${{ parameters.sourceRegistry }}
-
-          # Fetch the list of repositories
-          echo "Fetching repositories from ${{ parameters.sourceRegistry }}..."
-          repositories=$(az acr repository list --name ${{ parameters.sourceRegistry }} --output json)
-
-          # Loop through the image names:
-          for repository in $(echo $repositories | jq -r '.[]')
-          do
-            # Get all images tagged with the source tag:
-            echo "##[debug] Pulling $repository:${{ parameters.selectImageTag }}..."
-
-            az acr import --name ${{ parameters.sourceRegistry }} \
-            --source ${{ parameters.sourceRegistry }}.azurecr.io/$repository:${{ parameters.selectImageTag }} \
-            --image $repository:${{ parameters.addImageTag }} \
-            --force
+          # Prerequisite: A DNS A record for the chosen Dev ACR must exist in the Prod privatelink.azurecr.io zone, resolving to the public IP for that ACR
+          set -eo pipefail
+          echo "##[debug] Authenticating with container registry ${{ parameters.sourceRegistry }}..."
+          az acr login --name ${{ parameters.sourceRegistry }}
+          # az acr check-health --name ${{ parameters.sourceRegistry }} --yes
+          if [[ "${{ parameters.sourceRegistry }}" == ${{ parameters.destRegistry }} ]]; then
+            src_reg_prefix="${{ parameters.sourceRegistry }}.azurecr.io/" # omitted when the source registry is in a different subscription
+          else
+            [[ "${{ parameters.sourceRegistry }}" =~ dev ]] && cmdopt_sub="--subscription ${TF_VAR_HUB_SUBSCRIPTION_ID}"
+            source_registry_id=$(az acr show --name ${{ parameters.sourceRegistry }} ${cmdopt_sub} --query id --output tsv)
+            cmdopt_reg="--registry ${source_registry_id}" # needed when the source registry is in a different subscription
+            echo "##[debug] Authenticating with container registry ${{ parameters.destRegistry }}..."
+            az acr login --name ${{ parameters.destRegistry }}
+            # az acr check-health --name ${{ parameters.destRegistry }} --yes
+          fi
+          [[ "${{ parameters.destRegistry }}" =~ dev ]] && az account set -s ${TF_VAR_HUB_SUBSCRIPTION_ID}
+          for repo in $(az acr repository list --name ${{ parameters.sourceRegistry }} --output tsv); do
+            echo "##[debug] Importing ${repo}:${{ parameters.selectImageTag }}..."
+            az acr import --name ${{ parameters.destRegistry }} --source ${src_reg_prefix}${repo}:${{ parameters.selectImageTag }} --image ${repo}:${{ parameters.addImageTag }} ${cmdopt_reg} --force
+            if [[ "${{ parameters.sourceRegistry }}" != ${{ parameters.destRegistry }} ]]; then
+              image_sha=$(az acr manifest show-metadata --registry ${{ parameters.sourceRegistry }} --name ${repo}:${{ parameters.selectImageTag }} --query digest --output tsv --only-show-errors)
+              for tag in $(az acr manifest list-metadata --registry ${{ parameters.sourceRegistry }} --name ${repo} --query "[?digest=='${image_sha}'].tags[]" --output tsv --only-show-errors | grep -E '^(pr[0-9]+|[a-f0-9]{7})$'); do
+                echo "##[debug] Adding tag ${repo}:${tag}..."
+                az acr import --name ${{ parameters.destRegistry }} --source ${{ parameters.destRegistry }}.azurecr.io/${repo}:${{ parameters.addImageTag }} --image ${repo}:${tag} --force
+              done
+            fi
+            echo
           done

--- a/.azuredevops/pipelines/acr-image-retag.yaml
+++ b/.azuredevops/pipelines/acr-image-retag.yaml
@@ -89,8 +89,10 @@ stages:
             echo "##[debug] Importing ${repo}:${SELECT_IMAGE_TAG}..."
             az acr import --name ${DEST_REGISTRY} --source ${src_reg_prefix}${repo}:${SELECT_IMAGE_TAG} --image ${repo}:${ADD_IMAGE_TAG} ${cmdopt_reg} --force
             if [[ "${SRC_REGISTRY}" != ${DEST_REGISTRY} ]]; then
-              image_sha=$(az acr manifest show-metadata --registry ${SRC_REGISTRY} --name ${repo}:${SELECT_IMAGE_TAG} --query digest --output tsv --only-show-errors)
-              for tag in $(az acr manifest list-metadata --registry ${SRC_REGISTRY} --name ${repo} --query "[?digest=='${image_sha}'].tags[]" --output tsv --only-show-errors | grep -E '^(pr[0-9]+|[a-f0-9]{7})$'); do
+              # image_sha=$(az acr manifest show-metadata --registry ${SRC_REGISTRY} --name ${repo}:${SELECT_IMAGE_TAG} --query digest --output tsv --only-show-errors)
+              image_sha=$(az acr repository show --name ${SRC_REGISTRY} --image ${repo}:${SELECT_IMAGE_TAG} --query digest --output tsv)
+              #for tag in $(az acr manifest list-metadata --registry ${SRC_REGISTRY} --name ${repo} --query "[?digest=='${image_sha}'].tags[]" --output tsv --only-show-errors | grep -E '^(pr[0-9]+|[a-f0-9]{7})$'); do
+              for tag in $(az acr repository show --name ${SRC_REGISTRY} --image ${repo}@${image_sha} --query "tags" --output tsv | grep -E '^(pr[0-9]+|[a-f0-9]{7})$'); do
                 echo "##[debug] Adding tag ${repo}:${tag}..."
                 az acr import --name ${DEST_REGISTRY} --source ${DEST_REGISTRY}.azurecr.io/${repo}:${ADD_IMAGE_TAG} --image ${repo}:${tag} --force
               done

--- a/.azuredevops/pipelines/acr-image-retag.yaml
+++ b/.azuredevops/pipelines/acr-image-retag.yaml
@@ -59,6 +59,7 @@ stages:
       SELECT_IMAGE_TAG: ${{ parameters.selectImageTag }}
       ADD_IMAGE_TAG: ${{ parameters.addImageTag }}
     steps:
+    - checkout: none
     - task: AzureCLI@2
       name: tag_integration
       displayName: Publish $(SELECT_IMAGE_TAG) images to ${{ parameters.addImageTag }}
@@ -71,9 +72,20 @@ stages:
         inlineScript: |
           # Prerequisite: A DNS A record for the chosen Dev ACR must exist in the Prod privatelink.azurecr.io zone, resolving to the public IP for that ACR
           set -eo pipefail
+          declare -a pids
+
+          wait_for_completion() {
+            # acr tasks are backgrounded for parallelism
+            local -n arr=$1
+            for pid in "${arr[@]}"; do
+              wait ${pid}
+            done
+          }
+
           echo "##[debug] Authenticating with container registry ${SRC_REGISTRY}..."
           az acr login --name ${SRC_REGISTRY}
           # az acr check-health --name ${SRC_REGISTRY} --yes
+
           if [[ "${SRC_REGISTRY}" == ${DEST_REGISTRY} ]]; then
             src_reg_prefix="${SRC_REGISTRY}.azurecr.io/" # omitted when the source registry is in a different subscription
           else
@@ -84,18 +96,28 @@ stages:
             az acr login --name ${DEST_REGISTRY}
             # az acr check-health --name ${DEST_REGISTRY} --yes
           fi
+
           [[ "${DEST_REGISTRY}" =~ dev ]] && az account set -s ${TF_VAR_HUB_SUBSCRIPTION_ID}
-          for repo in $(az acr repository list --name ${SRC_REGISTRY} --output tsv); do
+          repos=$(az acr repository list --name ${SRC_REGISTRY} --output tsv)
+
+          for repo in ${repos}; do
             echo "##[debug] Importing ${repo}:${SELECT_IMAGE_TAG}..."
-            az acr import --name ${DEST_REGISTRY} --source ${src_reg_prefix}${repo}:${SELECT_IMAGE_TAG} --image ${repo}:${ADD_IMAGE_TAG} ${cmdopt_reg} --force
-            if [[ "${SRC_REGISTRY}" != ${DEST_REGISTRY} ]]; then
-              # image_sha=$(az acr manifest show-metadata --registry ${SRC_REGISTRY} --name ${repo}:${SELECT_IMAGE_TAG} --query digest --output tsv --only-show-errors)
+            az acr import --name ${DEST_REGISTRY} --source ${src_reg_prefix}${repo}:${SELECT_IMAGE_TAG} --image ${repo}:${ADD_IMAGE_TAG} ${cmdopt_reg} --force &
+            pids+=($!)
+          done
+          wait_for_completion pids
+
+          if [[ "${SRC_REGISTRY}" != ${DEST_REGISTRY} ]]; then
+            # To minimise data transfers, use only the destination acr to add other relevant tags taken from the source registry (PR ref, commit hash)
+            pids=()
+            for repo in ${repos}; do
               image_sha=$(az acr repository show --name ${SRC_REGISTRY} --image ${repo}:${SELECT_IMAGE_TAG} --query digest --output tsv)
-              #for tag in $(az acr manifest list-metadata --registry ${SRC_REGISTRY} --name ${repo} --query "[?digest=='${image_sha}'].tags[]" --output tsv --only-show-errors | grep -E '^(pr[0-9]+|[a-f0-9]{7})$'); do
               for tag in $(az acr repository show --name ${SRC_REGISTRY} --image ${repo}@${image_sha} --query "tags" --output tsv | grep -E '^(pr[0-9]+|[a-f0-9]{7})$'); do
                 echo "##[debug] Adding tag ${repo}:${tag}..."
-                az acr import --name ${DEST_REGISTRY} --source ${DEST_REGISTRY}.azurecr.io/${repo}:${ADD_IMAGE_TAG} --image ${repo}:${tag} --force
+                az acr import --name ${DEST_REGISTRY} --source ${DEST_REGISTRY}.azurecr.io/${repo}:${ADD_IMAGE_TAG} --image ${repo}:${tag} --force &
+                pids+=($!)
               done
-              echo
-            fi
-          done
+            done
+            wait_for_completion pids
+          fi
+

--- a/.azuredevops/pipelines/acr-image-retag.yaml
+++ b/.azuredevops/pipelines/acr-image-retag.yaml
@@ -51,13 +51,17 @@ stages:
   jobs:
   - job: re_tag
     pool:
-      # vmImage: ubuntu-latest
       name: private-pool-prod-uks
     displayName: Update/copy Docker images with new tag
+    variables:
+      SRC_REGISTRY: ${{ parameters.sourceRegistry }}
+      DEST_REGISTRY: ${{ parameters.destRegistry }}
+      SELECT_IMAGE_TAG: ${{ parameters.selectImageTag }}
+      ADD_IMAGE_TAG: ${{ parameters.addImageTag }}
     steps:
     - task: AzureCLI@2
       name: tag_integration
-      displayName: Publish ${{ parameters.selectImageTag }} images to ${{ parameters.addImageTag }}
+      displayName: Publish $(SELECT_IMAGE_TAG) images to ${{ parameters.addImageTag }}
       inputs:
         azureSubscription: sc-communication-management-prod
         addSpnToEnvironment: true
@@ -67,29 +71,29 @@ stages:
         inlineScript: |
           # Prerequisite: A DNS A record for the chosen Dev ACR must exist in the Prod privatelink.azurecr.io zone, resolving to the public IP for that ACR
           set -eo pipefail
-          echo "##[debug] Authenticating with container registry ${{ parameters.sourceRegistry }}..."
-          az acr login --name ${{ parameters.sourceRegistry }}
-          # az acr check-health --name ${{ parameters.sourceRegistry }} --yes
-          if [[ "${{ parameters.sourceRegistry }}" == ${{ parameters.destRegistry }} ]]; then
-            src_reg_prefix="${{ parameters.sourceRegistry }}.azurecr.io/" # omitted when the source registry is in a different subscription
+          echo "##[debug] Authenticating with container registry ${SRC_REGISTRY}..."
+          az acr login --name ${SRC_REGISTRY}
+          # az acr check-health --name ${SRC_REGISTRY} --yes
+          if [[ "${SRC_REGISTRY}" == ${DEST_REGISTRY} ]]; then
+            src_reg_prefix="${SRC_REGISTRY}.azurecr.io/" # omitted when the source registry is in a different subscription
           else
-            [[ "${{ parameters.sourceRegistry }}" =~ dev ]] && cmdopt_sub="--subscription ${TF_VAR_HUB_SUBSCRIPTION_ID}"
-            source_registry_id=$(az acr show --name ${{ parameters.sourceRegistry }} ${cmdopt_sub} --query id --output tsv)
+            [[ "${SRC_REGISTRY}" =~ dev ]] && cmdopt_sub="--subscription ${TF_VAR_HUB_SUBSCRIPTION_ID}"
+            source_registry_id=$(az acr show --name ${SRC_REGISTRY} ${cmdopt_sub} --query id --output tsv)
             cmdopt_reg="--registry ${source_registry_id}" # needed when the source registry is in a different subscription
-            echo "##[debug] Authenticating with container registry ${{ parameters.destRegistry }}..."
-            az acr login --name ${{ parameters.destRegistry }}
-            # az acr check-health --name ${{ parameters.destRegistry }} --yes
+            echo "##[debug] Authenticating with container registry ${DEST_REGISTRY}..."
+            az acr login --name ${DEST_REGISTRY}
+            # az acr check-health --name ${DEST_REGISTRY} --yes
           fi
-          [[ "${{ parameters.destRegistry }}" =~ dev ]] && az account set -s ${TF_VAR_HUB_SUBSCRIPTION_ID}
-          for repo in $(az acr repository list --name ${{ parameters.sourceRegistry }} --output tsv); do
-            echo "##[debug] Importing ${repo}:${{ parameters.selectImageTag }}..."
-            az acr import --name ${{ parameters.destRegistry }} --source ${src_reg_prefix}${repo}:${{ parameters.selectImageTag }} --image ${repo}:${{ parameters.addImageTag }} ${cmdopt_reg} --force
-            if [[ "${{ parameters.sourceRegistry }}" != ${{ parameters.destRegistry }} ]]; then
-              image_sha=$(az acr manifest show-metadata --registry ${{ parameters.sourceRegistry }} --name ${repo}:${{ parameters.selectImageTag }} --query digest --output tsv --only-show-errors)
-              for tag in $(az acr manifest list-metadata --registry ${{ parameters.sourceRegistry }} --name ${repo} --query "[?digest=='${image_sha}'].tags[]" --output tsv --only-show-errors | grep -E '^(pr[0-9]+|[a-f0-9]{7})$'); do
+          [[ "${DEST_REGISTRY}" =~ dev ]] && az account set -s ${TF_VAR_HUB_SUBSCRIPTION_ID}
+          for repo in $(az acr repository list --name ${SRC_REGISTRY} --output tsv); do
+            echo "##[debug] Importing ${repo}:${SELECT_IMAGE_TAG}..."
+            az acr import --name ${DEST_REGISTRY} --source ${src_reg_prefix}${repo}:${SELECT_IMAGE_TAG} --image ${repo}:${ADD_IMAGE_TAG} ${cmdopt_reg} --force
+            if [[ "${SRC_REGISTRY}" != ${DEST_REGISTRY} ]]; then
+              image_sha=$(az acr manifest show-metadata --registry ${SRC_REGISTRY} --name ${repo}:${SELECT_IMAGE_TAG} --query digest --output tsv --only-show-errors)
+              for tag in $(az acr manifest list-metadata --registry ${SRC_REGISTRY} --name ${repo} --query "[?digest=='${image_sha}'].tags[]" --output tsv --only-show-errors | grep -E '^(pr[0-9]+|[a-f0-9]{7})$'); do
                 echo "##[debug] Adding tag ${repo}:${tag}..."
-                az acr import --name ${{ parameters.destRegistry }} --source ${{ parameters.destRegistry }}.azurecr.io/${repo}:${{ parameters.addImageTag }} --image ${repo}:${tag} --force
+                az acr import --name ${DEST_REGISTRY} --source ${DEST_REGISTRY}.azurecr.io/${repo}:${ADD_IMAGE_TAG} --image ${repo}:${tag} --force
               done
+              echo
             fi
-            echo
           done

--- a/.azuredevops/pipelines/cd-infrastructure-dev-audit.yaml
+++ b/.azuredevops/pipelines/cd-infrastructure-dev-audit.yaml
@@ -14,7 +14,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: a0503c04da0f62f2985105a28fd94d91a7f5bfa0
+      ref: fa58dc978491f04e1efab73cbf8e2228a351bf81
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/cd-infrastructure-dev-core.yaml
+++ b/.azuredevops/pipelines/cd-infrastructure-dev-core.yaml
@@ -14,7 +14,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: a0503c04da0f62f2985105a28fd94d91a7f5bfa0
+      ref: fa58dc978491f04e1efab73cbf8e2228a351bf81
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/cd-infrastructure-int-audit.yaml
+++ b/.azuredevops/pipelines/cd-infrastructure-int-audit.yaml
@@ -14,7 +14,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: a0503c04da0f62f2985105a28fd94d91a7f5bfa0
+      ref: fa58dc978491f04e1efab73cbf8e2228a351bf81
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/cd-infrastructure-int-core.yaml
+++ b/.azuredevops/pipelines/cd-infrastructure-int-core.yaml
@@ -14,7 +14,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: a0503c04da0f62f2985105a28fd94d91a7f5bfa0
+      ref: fa58dc978491f04e1efab73cbf8e2228a351bf81
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/cd-infrastructure-nft-audit.yaml
+++ b/.azuredevops/pipelines/cd-infrastructure-nft-audit.yaml
@@ -14,7 +14,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: a0503c04da0f62f2985105a28fd94d91a7f5bfa0
+      ref: fa58dc978491f04e1efab73cbf8e2228a351bf81
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/cd-infrastructure-nft-core.yaml
+++ b/.azuredevops/pipelines/cd-infrastructure-nft-core.yaml
@@ -14,7 +14,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: a0503c04da0f62f2985105a28fd94d91a7f5bfa0
+      ref: fa58dc978491f04e1efab73cbf8e2228a351bf81
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/cd-infrastructure-prd-audit.yaml
+++ b/.azuredevops/pipelines/cd-infrastructure-prd-audit.yaml
@@ -14,7 +14,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: a0503c04da0f62f2985105a28fd94d91a7f5bfa0
+      ref: fa58dc978491f04e1efab73cbf8e2228a351bf81
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/cd-infrastructure-prd-core.yaml
+++ b/.azuredevops/pipelines/cd-infrastructure-prd-core.yaml
@@ -14,7 +14,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: a0503c04da0f62f2985105a28fd94d91a7f5bfa0
+      ref: fa58dc978491f04e1efab73cbf8e2228a351bf81
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/cd-infrastructure-pre-audit.yaml
+++ b/.azuredevops/pipelines/cd-infrastructure-pre-audit.yaml
@@ -14,7 +14,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: a0503c04da0f62f2985105a28fd94d91a7f5bfa0
+      ref: fa58dc978491f04e1efab73cbf8e2228a351bf81
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/cd-infrastructure-pre-core.yaml
+++ b/.azuredevops/pipelines/cd-infrastructure-pre-core.yaml
@@ -14,7 +14,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: a0503c04da0f62f2985105a28fd94d91a7f5bfa0
+      ref: fa58dc978491f04e1efab73cbf8e2228a351bf81
       endpoint: NHSDigital
 
 variables:


### PR DESCRIPTION
## Description

ACR image copying and re-tagging pipeline can now retag images in either Dev or Prod project ACRs, and migrate images between them. It preserves the PR and commit ref tags when migrating images.

One significant improvement here is the parallelism of the `az acr` jobs, which should result in a rapid pipeline execution, even for projects which have many Docker images. Furthermore there is no need for artifact storage nor multiple pipeline stages.

Linked to https://github.com/NHSDigital/dtos-devops-templates/pull/79

Example successful run:
https://dev.azure.com/nhse-dtos/dtos-communication-management/_build/results?buildId=10156&view=results

## Context

Previously, Docker image promotion into Prod environments was only possible via VM with Docker installed - by downloading, re-tagging, and uploading each image.

This new approach achieves the same result but uses the destination ACR to pull and re-tag the images itself, and using parallelism to optimise run duration.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
