### PR TITLE
Make recipient id generator resilient to blank fields

### DIFF
--- a/src/shared/uuid_generator.py
+++ b/src/shared/uuid_generator.py
@@ -3,12 +3,12 @@ import uuid
 
 
 def recipient_id(message_data: dict) -> str:
-    str_val: str = ",".join([
+    str_val: str = ",".join(list(filter(None, (
         message_data["appointment_date"],
         message_data["appointment_time"],
         message_data["date_of_birth"],
         message_data["nhs_number"],
-    ])
+    ))))
     return reference_uuid(str_val)
 
 

--- a/tests/unit/shared/test_uuid_generator.py
+++ b/tests/unit/shared/test_uuid_generator.py
@@ -19,6 +19,17 @@ def test_recipient_id():
     assert uuid_generator.recipient_id(message_data) == "43b1d23b-42b5-9700-e677-1159c15d378f"
 
 
+def test_recipient_id_with_missing_values():
+    """Tests the predictable conversion of a dict containing missing values to a UUID."""
+    message_data = {
+        "appointment_date": "2025-02-01",
+        "appointment_time": "12:00",
+        "date_of_birth": "",
+        "nhs_number": "1234567890",
+    }
+    assert uuid_generator.recipient_id(message_data) == "603e1836-4231-248e-3804-527a05617def"
+
+
 def test_uuid4_str(monkeypatch):
     """Tests the generation of a UUID4 string."""
     monkeypatch.setattr(uuid, "uuid4", lambda: uuid.UUID("c1a8b6c8-9f6b-4e1e-9d3f-3e7f4b8c0a9d"))


### PR DESCRIPTION


<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Something that we spotted with test data is a blank field will cause an exception, this was down to bad test data but filter empty field values out when generating the recipient id.
<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
