### PR TITLE
Log any exceptions when calling send_message

### DIFF
--- a/src/functions/notify/notifier.py
+++ b/src/functions/notify/notifier.py
@@ -20,11 +20,15 @@ def send_messages(data: dict) -> str:
 
     if "recipients" in data:
         for message_data in data["recipients"]:
-            if "routing_plan" in message_data:
-                routing_plan_id = routing_plans.get_id(message_data.pop("routing_plan"))
+            try:
+                if "routing_plan" in message_data:
+                    routing_plan_id = routing_plans.get_id(message_data.pop("routing_plan"))
 
-            response: str = send_message(token, routing_plan_id, message_data, batch_id)
-            responses.append(response)
+                response: str = send_message(token, routing_plan_id, message_data, batch_id)
+                responses.append(response)
+            except Exception as e:
+                logging.error(f"Error sending message: {e}")
+                logging.error(f"Message data: {message_data}")
 
     return "\n".join(responses)
 


### PR DESCRIPTION


<!-- markdownlint-disable-next-line first-line-heading -->
## Description

We don't want to halt all message sending if an exception occurs when sending the batch of messages. Log the error and continue.
<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
