### PR TITLE
Add healthcheck endpoint to message status function

### DIFF
--- a/src/functions/message_status/function_app.py
+++ b/src/functions/message_status/function_app.py
@@ -35,3 +35,16 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
         status_code=status_code,
         body=json.dumps(body).encode("utf-8")
     )
+
+
+@app.function_name(name="MessageStatusHealthCheck")
+@app.route(
+    route="message-status/health-check",
+    auth_level=func.AuthLevel.ANONYMOUS,
+    methods=[func.HttpMethod.GET],
+)
+def health_check(req: func.HttpRequest) -> func.HttpResponse:
+    return func.HttpResponse(
+        status_code=200,
+        body=json.dumps({"status": "healthy"}).encode("utf-8")
+    )

--- a/tests/unit/message_status/test_function_app.py
+++ b/tests/unit/message_status/test_function_app.py
@@ -96,3 +96,14 @@ def test_main_verify_headers_missing(mocker, payload):
 
     assert response.status_code == 401
     assert response.get_body().decode("utf-8") == json.dumps({"status": "error"})
+
+
+def test_health_check():
+    """Test health check endpoint."""
+    request = func.HttpRequest(method="GET", url="/api/message-status/health-check", body=None)
+    func_call = function_app.health_check.build().get_user_function()
+
+    response = func_call(request)
+
+    assert response.status_code == 200
+    assert response.get_body().decode("utf-8") == json.dumps({"status": "healthy"})


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adds an http trigger for message status healthchecks. The healthcheck is as simple as possible for now.
This change won't have any effect in terms of monitoring until the relevant infrastructure PRs are merged and deployed.
<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
