### PR TITLE
minor updates to validators

### DIFF
--- a/src/notify/app/validators/request_validator.py
+++ b/src/notify/app/validators/request_validator.py
@@ -35,27 +35,16 @@ def verify_signature(headers: dict, body: dict, signature: str) -> bool:
 
 
 def verify_body(body: dict) -> tuple[bool, str]:
+    """Verify the request body against the schema."""
     try:
         body_data = body["data"]
+        if not isinstance(body_data, dict):
+            return False, "Data must be an object"
 
-        if isinstance(body_data, list):
-            if not body_data:
-                return False, "Empty data list"
-
-            # Get first item's type
-            schema_type = body_data[0]["type"]
-
-            # Verify all items have same type
-            if not all(item.get("type") == schema_type for item in body_data):
-                return False, "All items must have the same type"
-        else:
-            schema_type = body_data["type"]
-
+        schema_type = body_data["type"]
         return schema_validator.validate_with_schema(schema_type, body)
     except KeyError as e:
         return False, f"Invalid body: {e}"
-    except IndexError:
-        return False, "Invalid body: empty data list"
 
 
 def signature_secret() -> str:

--- a/tests/unit/notify/app/validators/test_request_validator.py
+++ b/tests/unit/notify/app/validators/test_request_validator.py
@@ -61,97 +61,53 @@ def test_verify_headers_invalid_api_key(setup):
     assert request_validator.verify_headers(headers, 'api_key') == (False, 'Invalid API key')
 
 
-def test_verify_body_empty_data_list(setup):
-    """Test that an empty data list fails verification."""
-    body = {"data": []}
-    assert request_validator.verify_body(body) == (False, "Empty data list")
-
-
-def test_verify_body_mixed_types(setup):
-    """Test that a list with mixed types fails verification."""
-    body = {
-        "data": [
-            {
-                "type": "MessageBatch",
-                "attributes": {
-                    "routingPlanId": "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
-                    "messageBatchReference": "da0b1495-c7cb-468c-9d81-07dee089d728",
-                    "messages": [{
-                        "messageReference": "703b8008-545d-4a04-bb90-1f2946ce1575",
-                        "recipient": {
-                            "nhsNumber": "9990548609",
-                            "dateOfBirth": "1990-01-01"
-                        }
-                    }]
-                }
-            },
-            {
-                "type": "Message",  # Different type
-                "attributes": {
-                    "routingPlanId": "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
-                    "messageBatchReference": "da0b1495-c7cb-468c-9d81-07dee089d729",
-                    "messages": [{
-                        "messageReference": "703b8008-545d-4a04-bb90-1f2946ce1576",
-                        "recipient": {
-                            "nhsNumber": "9990548610",
-                            "dateOfBirth": "1990-01-01"
-                        }
-                    }]
-                }
-            }
-        ]
-    }
-    assert request_validator.verify_body(body) == (False, "All items must have the same type")
-
-
-def test_verify_body_valid_list(setup):
-    """Test that a list with same types passes verification."""
-    body = {
-        "data": [{
-            "type": "MessageBatch",
-            "attributes": {
-                "routingPlanId": "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
-                "messageBatchReference": "da0b1495-c7cb-468c-9d81-07dee089d728",
-                "messages": [{
-                    "messageReference": "703b8008-545d-4a04-bb90-1f2946ce1575",
-                    "recipient": {
-                        "nhsNumber": "9990548609",
-                        "dateOfBirth": "1990-01-01"
-                    },
-                    "personalisation": {
-                        "appointment_date": "2024-03-20",
-                        "appointment_location": "City Hospital"
-                    }
-                }]
-            }
-        },{
-            "type": "MessageBatch",
-            "attributes": {
-                "routingPlanId": "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
-                "messageBatchReference": "da0b1495-c7cb-468c-9d81-07dee089d729",
-                "messages": [{
-                    "messageReference": "703b8008-545d-4a04-bb90-1f2946ce1576",
-                    "recipient": {
-                        "nhsNumber": "9990548610",
-                        "dateOfBirth": "1990-01-01"
-                    },
-                    "personalisation": {
-                        "appointment_date": "2024-03-21",
-                        "appointment_location": "City Hospital"
-                    }
-                }]
-            }
-        }]
-    }
-
-    assert request_validator.verify_body(body)[0] == True
+def test_verify_body_empty_object(setup):
+    """Test that an empty data object fails verification."""
+    body = {"data": {}}
+    assert request_validator.verify_body(body) == (False, "Invalid body: 'type'")
 
 
 def test_verify_body_missing_type(setup):
     """Test that missing type field fails verification."""
     body = {
-        "data": [
+        "data":
             {"content": "test"}
-        ]
     }
     assert request_validator.verify_body(body) == (False, "Invalid body: 'type'")
+
+
+def test_verify_body_valid_batch(setup):
+    """Test that a batch with multiple messages passes verification."""
+    body = {
+        "data": {  # Single message batch
+            "type": "MessageBatch",
+            "attributes": {
+                "routingPlanId": "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
+                "messageBatchReference": "da0b1495-c7cb-468c-9d81-07dee089d728",
+                "messages": [  # Multiple messages in the batch
+                    {
+                        "messageReference": "703b8008-545d-4a04-bb90-1f2946ce1575",
+                        "recipient": {
+                            "nhsNumber": "9990548609"
+                        },
+                        "personalisation": {
+                            "appointment_date": "2024-03-20",
+                            "appointment_location": "City Hospital"
+                        }
+                    },
+                    {
+                        "messageReference": "703b8008-545d-4a04-bb90-1f2946ce1576",
+                        "recipient": {
+                            "nhsNumber": "9990548610"
+                        },
+                        "personalisation": {
+                            "appointment_date": "2024-03-21",
+                            "appointment_location": "City Hospital"
+                        }
+                    }
+                ]
+            }
+        }
+    }
+
+    assert request_validator.verify_body(body) == (True, "")


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Small PR to add a couple of extra bits of validation to validate the request body for the batch endpoint. Unless I'm missing something (please double-check in case I am) - the `data` field in BatchMessages needs to be an object, and it's the `messages` field that provides a list of messages. 

## Context

Verifies all items have the same `type` (incidentally...we should probably think about whether we need that as part of the request body or not. Removing would mean eliminating this as a category of errors, but would mean diverging from the Notify API)
Uses isinstance() for type checking
Provides more specific error messages in certain cases (such as specifying data as an object)
Has made me realise that `dateOfBirth` isn't in the schema for batch messages! @steventux something for us to discuss, but I'll have to catch you up with the latest conversation with Clinical Assurance too because there's an extra consideration here now

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ X ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ X ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ X ] I have followed the code style of the project
- [ X ] I have added tests to cover my changes
- [ X ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ X ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
