### PR TITLE
Increase delay to allow function app trigger time

### DIFF
--- a/tests/end_to_end/runner/test_csv_file_upload.py
+++ b/tests/end_to_end/runner/test_csv_file_upload.py
@@ -49,7 +49,8 @@ def test_csv_file_upload():
 def test_csv_file_upload_saves_to_database():
     assert upload_file_to_blob_storage()
 
-    time.sleep(1.5)
+    # Wait for the function app to be triggered, make a request to NHS Notify Stub and save the data to the database
+    time.sleep(2)
 
     with Session(database.engine()) as session:
         message_batch = session.scalars(select(models.MessageBatch)).all()[0]


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Increase delay before database record assertions to 2 seconds.

<!-- Describe your changes in detail. -->

## Context

1.5 seconds was marginal in allowing the blob trigger to execute, send a request to the NHS Notify API Stub and then save things to the database. 
<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.