### PR TITLE
Add dynamic timestamps to NHS Notify API stub server responses

### DIFF
--- a/tests/end_to_end/nhs_notify_api_stub/app.py
+++ b/tests/end_to_end/nhs_notify_api_stub/app.py
@@ -30,7 +30,7 @@ def message_batches():
                     "id": "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
                     "name": "Plan Abc",
                     "version": "ztoe2qRAM8M8vS0bqajhyEBcvXacrGPp",
-                    "createdDate": "2023-11-17T14:27:51.413Z"
+                    "createdDate": time.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
                 },
                 "messages": messages
             }
@@ -94,7 +94,7 @@ def channel_status(message, status="delivered", supplier_status="read"):
                     "channelStatus": status,
                     "channelStatusDescription": " ",
                     "supplierStatus": supplier_status,
-                    "timestamp": "2023-11-17T14:27:51.413Z",
+                    "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                     "retryCount": 1
                 },
                 "links": {
@@ -124,7 +124,7 @@ def message_status(message, message_status="sending", channel_status="delivered"
                             "channelStatus": channel_status
                         }
                     ],
-                    "timestamp": "2023-11-17T14:27:51.413Z",
+                    "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
                     "routingPlan": {
                         "id": "b838b13c-f98c-4def-93f0-515d4e4f4ee1",
                         "name": "Plan Abc",


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adds dynamic timestamps to NHS Notify API stub responses, you know for realism.

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
