### PR TITLE
Validate generated message batch post body on stub API

### DIFF
--- a/tests/end_to_end/nhs_notify_api_stub/Dockerfile
+++ b/tests/end_to_end/nhs_notify_api_stub/Dockerfile
@@ -4,9 +4,10 @@ FROM --platform=$BUILDPLATFORM python:3.10-alpine AS builder
 WORKDIR /app
 
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip3 install dotenv flask requests
+    pip3 install dotenv flask jsonschema requests
 
 COPY --from=root_dir /src/notify/app/utils/ /app/utils/
+COPY --from=root_dir /src/notify/app/validators/schemas/nhs-notify.json /app/schema.json
 COPY --from=root_dir .env.compose /app/.env
 COPY . /app
 


### PR DESCRIPTION

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

We serve a default happy-path response from the NHS Notify API stub server in our end to end tests, but this won't tell us if we start sending an invalid POST body. 

Add validation of the incoming post body, this will catch any changes which produce an invalid request.
We already have integration test coverage for invalid payloads but this ensures we don't have a false sense of security with the stubbed server.

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
