### PR TITLE
Include the client bearer token if present in headers

### DIFF
--- a/src/notify/app/route_handlers/message.py
+++ b/src/notify/app/route_handlers/message.py
@@ -21,7 +21,7 @@ def batch():
     if not valid_body:
         return {"status": "failed", "error": error_message}, 422
 
-    status_code, response = message_batch_dispatcher.dispatch(json_data)
+    status_code, response = message_batch_dispatcher.dispatch(json_data, bearer_token())
     status = "success" if status_code == 201 else "failed"
 
     return {"status": status, "response": response}, status_code
@@ -33,3 +33,10 @@ def client_api_key() -> str:
 
 def signature_secret() -> str:
     return f"{os.getenv('CLIENT_APPLICATION_ID')}.{os.getenv('CLIENT_API_KEY')}"
+
+
+def bearer_token() -> str | None:
+    header_value = request.headers.get("Authorization")
+    if header_value and header_value.startswith("Bearer "):
+        return header_value.split(" ")[1]
+    return None

--- a/src/notify/app/services/message_batch_dispatcher.py
+++ b/src/notify/app/services/message_batch_dispatcher.py
@@ -7,8 +7,11 @@ import requests
 import uuid
 
 
-def dispatch(body: dict) -> tuple[int, str]:
-    response = requests.post(url(), json=body, headers=headers(), timeout=10)
+def dispatch(body: dict, bearer_token: str | None = None) -> tuple[int, str]:
+    if not bearer_token:
+        bearer_token = access_token.get_token()
+
+    response = requests.post(url(), json=body, headers=headers(bearer_token), timeout=10)
     logging.info("Response from Notify API %s: %s", url(), response.status_code)
 
     success = response.status_code == 201
@@ -18,12 +21,12 @@ def dispatch(body: dict) -> tuple[int, str]:
     return response.status_code, response.json()
 
 
-def headers() -> dict:
+def headers(bearer_token) -> dict:
     return {
         "content-type": "application/vnd.api+json",
         "accept": "application/vnd.api+json",
         "x-correlation-id": str(uuid.uuid4()),
-        "authorization": "Bearer " + access_token.get_token(),
+        "authorization": "Bearer " + bearer_token,
     }
 
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This commit allows the incoming Authorization header value to be preserved and used in the request made to the NHS Notify API, otherwise the default credentials are used to generate the JWT / Bearer token. This fallback preserves existing BSO file upload functionality.

<!-- Describe your changes in detail. -->

## Context

NHS Notify need to identify requests from clients to ensure the correct routing plans are in use.

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
