### PR TITLE
Remove hmac verification on message batch endpoint

### DIFF
--- a/src/notify/app/route_handlers/message.py
+++ b/src/notify/app/route_handlers/message.py
@@ -35,8 +35,8 @@ def signature_secret() -> str:
     return f"{os.getenv('CLIENT_APPLICATION_ID')}.{os.getenv('CLIENT_API_KEY')}"
 
 
-def bearer_token() -> str | None:
+def bearer_token() -> str:
     header_value = request.headers.get("Authorization")
     if header_value and header_value.startswith("Bearer "):
         return header_value.split(" ")[1]
-    return None
+    return "invalid"

--- a/src/notify/app/route_handlers/message.py
+++ b/src/notify/app/route_handlers/message.py
@@ -1,20 +1,13 @@
 from flask import request
 import app.validators.request_validator as request_validator
 import app.services.message_batch_dispatcher as message_batch_dispatcher
-import os
 
 
 def batch():
+    if not request.headers.get("Authorization"):
+        return {"status": "failed", "error": "Authorization header not present"}, 401
+
     json_data = request.json or {}
-    valid_headers, error_message = request_validator.verify_headers(
-        dict(request.headers), client_api_key()
-    )
-
-    if not valid_headers:
-        return {"status": "failed", "error": error_message}, 401
-
-    if not request_validator.verify_signature(dict(request.headers), json_data, signature_secret()):
-        return {"status": "failed", "error": "Invalid signature"}, 403
 
     valid_body, error_message = request_validator.verify_body(json_data)
 
@@ -25,14 +18,6 @@ def batch():
     status = "success" if status_code == 201 else "failed"
 
     return {"status": status, "response": response}, status_code
-
-
-def client_api_key() -> str:
-    return str(os.getenv("CLIENT_API_KEY"))
-
-
-def signature_secret() -> str:
-    return f"{os.getenv('CLIENT_APPLICATION_ID')}.{os.getenv('CLIENT_API_KEY')}"
 
 
 def bearer_token() -> str:

--- a/tests/end_to_end/runner/helpers.py
+++ b/tests/end_to_end/runner/helpers.py
@@ -1,19 +1,10 @@
-import app.utils.hmac_signature as hmac_signature
 import azure.storage.blob
 import dotenv
-import json
 import logging
 import os
 import requests
 
 dotenv.load_dotenv()
-
-
-def signature(body):
-    return hmac_signature.create_digest(
-        f"{os.getenv('CLIENT_APPLICATION_ID')}.{os.getenv('CLIENT_API_KEY')}",
-        json.dumps(body, sort_keys=True)
-    )
 
 
 def get_status_endpoint(batch_reference):
@@ -30,12 +21,9 @@ def get_status_endpoint(batch_reference):
 
 
 def post_message_batch_endpoint(message_batch_post_body):
-    hmac_signature = signature(message_batch_post_body)
-
     headers = {
+        "Authorization": "Bearer client_token",
         "Content-Type": "application/json",
-        "x-api-key": os.getenv('CLIENT_API_KEY'),
-        "x-hmac-sha256-signature": hmac_signature,
     }
 
     return requests.post(

--- a/tests/integration/notify/app/route_handlers/test_message_batch.py
+++ b/tests/integration/notify/app/route_handlers/test_message_batch.py
@@ -79,6 +79,30 @@ def test_message_batch_preserves_auth_header(setup, client, message_batch_post_b
         assert adapter.last_request.headers["Authorization"] == "Bearer client_token"
 
 
+def test_message_batch_fails_with_invalid_auth_header(setup, client, message_batch_post_body):
+    """Test that missing Bearer token fails authentication."""
+    signature = hmac_signature.create_digest(
+        f"{os.getenv('CLIENT_APPLICATION_ID')}.{os.getenv('CLIENT_API_KEY')}",
+        json.dumps(message_batch_post_body, sort_keys=True)
+    )
+
+    headers = {
+        API_KEY_HEADER_NAME: "api_key",
+        SIGNATURE_HEADER_NAME: signature,
+    }
+
+    with requests_mock.Mocker() as rm:
+        adapter = rm.post(
+            "http://example.com/comms/v1/message-batches",
+            status_code=401,
+            json={"status": "failed", "error": "Unauthorized"}
+        )
+
+        response = client.post('/api/message/batch', json=message_batch_post_body, headers=headers)
+
+        assert response.status_code == 401
+        assert adapter.last_request.headers["Authorization"] == "Bearer invalid"
+
 
 def test_message_batch_fails_with_invalid_post_body(setup, client, message_batch_post_body):
     """Test that invalid request body fails schema validation."""

--- a/tests/integration/notify/app/route_handlers/test_message_batch.py
+++ b/tests/integration/notify/app/route_handlers/test_message_batch.py
@@ -1,8 +1,5 @@
 from app import create_app
 from app.validators.request_validator import API_KEY_HEADER_NAME, SIGNATURE_HEADER_NAME
-import app.utils.hmac_signature as hmac_signature
-import json
-import os
 import pytest
 import requests_mock
 
@@ -10,8 +7,6 @@ import requests_mock
 @pytest.fixture
 def setup(monkeypatch):
     """Set up environment variables for tests."""
-    monkeypatch.setenv('CLIENT_APPLICATION_ID', 'application_id')
-    monkeypatch.setenv('CLIENT_API_KEY', 'api_key')
     monkeypatch.setenv("NOTIFY_API_URL", "http://example.com")
 
 
@@ -21,24 +16,10 @@ def client():
     yield app.test_client()
 
 
-def test_message_batch_request_validation_fails(setup, client, message_batch_post_body):
-    """Test that invalid request header values fail HMAC signature validation."""
-    headers = {API_KEY_HEADER_NAME: "api_key", SIGNATURE_HEADER_NAME: "signature"}
-
-    response = client.post('/api/message/batch', json=message_batch_post_body, headers=headers)
-
-    assert response.status_code == 403
-    assert response.get_json() == {"status": "failed", "error": "Invalid signature"}
-
-
 def test_message_batch_succeeds(setup, client, message_batch_post_body, message_batch_post_response):
-    """Test that valid request header values pass HMAC signature validation."""
-    signature = hmac_signature.create_digest(
-        f"{os.getenv('CLIENT_APPLICATION_ID')}.{os.getenv('CLIENT_API_KEY')}",
-        json.dumps(message_batch_post_body, sort_keys=True)
-    )
+    """Test that valid auth header and payload succeeds."""
 
-    headers = {API_KEY_HEADER_NAME: "api_key", SIGNATURE_HEADER_NAME: signature}
+    headers = {"Authorization": "Bearer client_token"}
 
     with requests_mock.Mocker() as rm:
         rm.post(
@@ -54,16 +35,10 @@ def test_message_batch_succeeds(setup, client, message_batch_post_body, message_
 
 
 def test_message_batch_preserves_auth_header(setup, client, message_batch_post_body, message_batch_post_response):
-    """Test that valid request header values pass HMAC signature validation."""
-    signature = hmac_signature.create_digest(
-        f"{os.getenv('CLIENT_APPLICATION_ID')}.{os.getenv('CLIENT_API_KEY')}",
-        json.dumps(message_batch_post_body, sort_keys=True)
-    )
+    """Test that the supplied auth header is preserved in the request to the Notify API."""
 
     headers = {
-        API_KEY_HEADER_NAME: "api_key",
         "Authorization": "Bearer client_token",
-        SIGNATURE_HEADER_NAME: signature,
     }
 
     with requests_mock.Mocker() as rm:
@@ -80,15 +55,9 @@ def test_message_batch_preserves_auth_header(setup, client, message_batch_post_b
 
 
 def test_message_batch_fails_with_invalid_auth_header(setup, client, message_batch_post_body):
-    """Test that missing Bearer token fails authentication."""
-    signature = hmac_signature.create_digest(
-        f"{os.getenv('CLIENT_APPLICATION_ID')}.{os.getenv('CLIENT_API_KEY')}",
-        json.dumps(message_batch_post_body, sort_keys=True)
-    )
-
+    """Test that invalid Bearer token fails authentication."""
     headers = {
-        API_KEY_HEADER_NAME: "api_key",
-        SIGNATURE_HEADER_NAME: signature,
+        "Authorization": "some_invalid_value",
     }
 
     with requests_mock.Mocker() as rm:
@@ -104,15 +73,28 @@ def test_message_batch_fails_with_invalid_auth_header(setup, client, message_bat
         assert adapter.last_request.headers["Authorization"] == "Bearer invalid"
 
 
+def test_message_batch_fails_with_missing_auth_header(setup, client, message_batch_post_body):
+    """Test that missing auth header fails authentication."""
+    headers = {}
+
+    with requests_mock.Mocker() as rm:
+        adapter = rm.post(
+            "http://example.com/comms/v1/message-batches",
+            status_code=401,
+            json={"status": "failed", "error": "Authorization header not present"}
+        )
+
+        response = client.post('/api/message/batch', json=message_batch_post_body, headers=headers)
+
+        assert response.status_code == 401
+        assert response.get_json() == {"status": "failed", "error": "Authorization header not present"}
+
+
 def test_message_batch_fails_with_invalid_post_body(setup, client, message_batch_post_body):
     """Test that invalid request body fails schema validation."""
     message_batch_post_body["data"]["type"] = "invalid"
-    signature = hmac_signature.create_digest(
-        f"{os.getenv('CLIENT_APPLICATION_ID')}.{os.getenv('CLIENT_API_KEY')}",
-        json.dumps(message_batch_post_body, sort_keys=True)
-    )
 
-    headers = {API_KEY_HEADER_NAME: "api_key", SIGNATURE_HEADER_NAME: signature}
+    headers = {"Authorization": "Bearer client_token"}
 
     response = client.post('/api/message/batch', json=message_batch_post_body, headers=headers)
 


### PR DESCRIPTION
## Context

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-8364

We now preserve the Authorization header from the client on message batch POST requests.
The OAuth2 authorization server will reject invalid or expired bearer tokens from the auth header.
We no longer need to verify the HMAC signature on this endpoint.

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

For the POST /message/batch endpoint only:

- Ensure the Authorization header value is of the correct format (ie `Bearer xyz`)
- Reject requests with no auth header
- Remove HMAC signature verification 


<!-- Describe your changes in detail. -->


<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
