### PR TITLE
Add clients db migrations

### DIFF
--- a/src/notify/migrations/versions/37bae2d2c9ec_create_clients_table.py
+++ b/src/notify/migrations/versions/37bae2d2c9ec_create_clients_table.py
@@ -1,0 +1,33 @@
+"""Create clients table
+
+Revision ID: 37bae2d2c9ec
+Revises: 858ef6be78a4
+Create Date: 2025-05-28 11:53:47.645448
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '37bae2d2c9ec'
+down_revision: Union[str, None] = '858ef6be78a4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table('clients',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(), nullable=True),
+        sa.Column('description', sa.String(), nullable=True),
+        sa.Column('key', sa.UUID(), nullable=False),
+        sa.Column('created_at', sa.TIMESTAMP(), nullable=False, server_default=sa.text('NOW()')),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('clients')

--- a/src/notify/migrations/versions/e9702592451c_add_client_id_to_message_batches.py
+++ b/src/notify/migrations/versions/e9702592451c_add_client_id_to_message_batches.py
@@ -1,0 +1,35 @@
+"""Add client_id to message_batches
+
+Revision ID: e9702592451c
+Revises: 37bae2d2c9ec
+Create Date: 2025-05-28 12:02:06.784245
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e9702592451c'
+down_revision: Union[str, None] = '37bae2d2c9ec'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('message_batches',
+                sa.Column('client_id', sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        'fk_message_batches_client_id',
+        'message_batches',
+        'clients',
+        ['client_id'],
+        ['id'],
+        ondelete='CASCADE'
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('message_batches', 'client_id')


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Add `clients` database table with appropriate columns
- Add `message_batches.client_id` column and foreign key constraint, this is currently nullable as existing code does not populate this new column. Once this functionality is added we can add a NOT NULL constraint.

<!-- Describe your changes in detail. -->

## Context

Consumers of the Communication Management API should be identified when making requests. 
Data should be identifiable and restricted per consumer or "client".
This needs to be modelled in the database and in code so that we associate batches of messages with the client who created them. 

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [x] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
