### PR TITLE
Rename Client to MessageOrigin

### DIFF
--- a/src/notify/app/models.py
+++ b/src/notify/app/models.py
@@ -38,6 +38,14 @@ class MessageStatuses(enum.Enum):
 
 
 # Tables
+class MessageOrigin(Base):
+    __tablename__ = "message_origins"
+
+    id = Column(Integer, primary_key=True)
+    key = Column(String, unique=True, nullable=False)
+    created_at = Column(TIMESTAMP, nullable=False, server_default=func.now())
+
+
 class MessageBatch(Base):
     __tablename__ = "message_batches"
 
@@ -51,6 +59,7 @@ class MessageBatch(Base):
         postgresql.ENUM(MessageBatchStatuses, values_callable=lambda x: [e.value for e in x]),
         default=MessageBatchStatuses.NOT_SENT,
     )
+    message_origin_id = Column(Integer, ForeignKey("message_origins.id"), nullable=True)
 
 
 class Message(Base):

--- a/src/notify/migrations/versions/d053c7a3b44d_renaming_client_model_to_messageorigin.py
+++ b/src/notify/migrations/versions/d053c7a3b44d_renaming_client_model_to_messageorigin.py
@@ -1,0 +1,63 @@
+"""Renaming Client model to MessageOrigin
+
+Revision ID: d053c7a3b44d
+Revises: e9702592451c
+Create Date: 2025-07-11 15:20:24.337586
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'd053c7a3b44d'
+down_revision: Union[str, None] = 'e9702592451c'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ### create message_origins table ###
+    op.create_table('message_origins',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('key', sa.String(), nullable=False),
+    sa.Column('created_at', sa.TIMESTAMP(), server_default=sa.text('now()'), nullable=False),
+    sa.PrimaryKeyConstraint('id'),
+    sa.UniqueConstraint('key')
+    )
+    # ### add foreign key to message_batches ###
+    op.add_column('message_batches',
+                sa.Column('message_origin_id', sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        'fk_message_batches_message_origin_id',
+        'message_batches',
+        'message_origins',
+        ['message_origin_id'],
+        ['id'],
+        ondelete='CASCADE'
+    )
+    # ### drop clients ###
+    op.drop_constraint(op.f('fk_message_batches_client_id'), 'message_batches', type_='foreignkey')
+    op.drop_column('message_batches', 'client_id')
+    op.drop_table('clients')
+    # ### end Alembic commands ###
+
+
+def downgrade() -> None:
+    # ### Add client back ###
+    op.create_table('clients',
+    sa.Column('id', sa.INTEGER(), autoincrement=True, nullable=False),
+    sa.Column('name', sa.String(), autoincrement=False, nullable=True),
+    sa.Column('description', sa.String(), autoincrement=False, nullable=True),
+    sa.Column('key', sa.UUID(), autoincrement=False, nullable=False),
+    sa.Column('created_at', sa.TIMESTAMP(), server_default=sa.text('now()'), autoincrement=False, nullable=False),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.add_column('message_batches', sa.Column('client_id', sa.INTEGER(), autoincrement=False, nullable=True))
+    op.create_foreign_key(op.f('fk_message_batches_client_id'), 'message_batches', 'clients', ['client_id'], ['id'], ondelete='CASCADE')
+    # ### Drop message_origins ###
+    op.drop_constraint(op.f('fk_message_batches_message_origin_id'), 'message_batches', type_='foreignkey')
+    op.drop_column('message_batches', 'message_origin_id')
+    op.drop_table('message_origins')
+    # ### end Alembic commands ###


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
https://nhsd-jira.digital.nhs.uk/browse/DTOSS-9044

This model is going to be used to identify the senders/origin of message batches - we decided to make it be more specific than just Client (or Consumer)

I've just dropped the Client table rather than renaming, as we do not have any remote/production data (as far as I know??) in it yet and I'm making a few changes to columns anyway:

Updating the `key` to be a unique field, as this will be the human readable string sent by the service to identify requests. And removing the `name` and `description` fields until we think we might need them.

## Questions / Notes

* Are we happy with the naming? Some things we considered - an app like Manage could potentially want to use more than one key to identify different senders, such as teams or clinics or BSOs, so calling it a client or consumer ID didn't seem to make sense. 
* I've started the follow up work to add a `messageOriginKey` to requests to API - over here https://github.com/NHSDigital/dtos-communication-management/pull/281 
  * perhaps controversially, after chatting with Nimmo, we considered putting this in body of request rather than headers. 
  * The key will be a human-readable string for now, saved as a secret env variable on the client side 
  * that means the client will send a key in the response, and then our service transforms that to a foreign key ID from the MessageOrigin table - interested to hear thoughts on this approach.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
