### PR TITLE
rename Client to Consumer

### DIFF
--- a/src/notify/app/models.py
+++ b/src/notify/app/models.py
@@ -38,6 +38,14 @@ class MessageStatuses(enum.Enum):
 
 
 # Tables
+class Consumer(Base):
+    __tablename__ = "consumers"
+
+    id = Column(Integer, primary_key=True)
+    key = Column(String, unique=True, nullable=False)
+    created_at = Column(TIMESTAMP, nullable=False, server_default=func.now())
+
+
 class MessageBatch(Base):
     __tablename__ = "message_batches"
 
@@ -51,6 +59,7 @@ class MessageBatch(Base):
         postgresql.ENUM(MessageBatchStatuses, values_callable=lambda x: [e.value for e in x]),
         default=MessageBatchStatuses.NOT_SENT,
     )
+    consumer_id = Column(Integer, ForeignKey("consumers.id"), nullable=True)
 
 
 class Message(Base):

--- a/src/notify/migrations/versions/891274ce0411_renaming_client_model_to_consumer.py
+++ b/src/notify/migrations/versions/891274ce0411_renaming_client_model_to_consumer.py
@@ -1,0 +1,63 @@
+"""Renaming Client model to Consumer
+
+Revision ID: 891274ce0411
+Revises: e9702592451c
+Create Date: 2025-07-15 11:33:33.061927
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '891274ce0411'
+down_revision: Union[str, None] = 'e9702592451c'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ### create consumers table ###
+    op.create_table('consumers',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('key', sa.String(), nullable=False),
+    sa.Column('created_at', sa.TIMESTAMP(), server_default=sa.text('now()'), nullable=False),
+    sa.PrimaryKeyConstraint('id'),
+    sa.UniqueConstraint('key')
+    )
+    # ### add foreign key to message_batches ###
+    op.add_column('message_batches',
+                sa.Column('consumer_id', sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        'fk_message_batches_consumer_id',
+        'message_batches',
+        'consumers',
+        ['consumer_id'],
+        ['id'],
+        ondelete='CASCADE'
+    )
+    # ### drop clients ###
+    op.drop_constraint(op.f('fk_message_batches_client_id'), 'message_batches', type_='foreignkey')
+    op.drop_column('message_batches', 'client_id')
+    op.drop_table('clients')
+    # ### end Alembic commands ###
+
+
+def downgrade() -> None:
+    # ### Add client back ###
+    op.create_table('clients',
+    sa.Column('id', sa.INTEGER(), autoincrement=True, nullable=False),
+    sa.Column('name', sa.String(), autoincrement=False, nullable=True),
+    sa.Column('description', sa.String(), autoincrement=False, nullable=True),
+    sa.Column('key', sa.UUID(), autoincrement=False, nullable=False),
+    sa.Column('created_at', sa.TIMESTAMP(), server_default=sa.text('now()'), autoincrement=False, nullable=False),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.add_column('message_batches', sa.Column('client_id', sa.INTEGER(), autoincrement=False, nullable=True))
+    op.create_foreign_key(op.f('fk_message_batches_client_id'), 'message_batches', 'clients', ['client_id'], ['id'], ondelete='CASCADE')
+    # ### Drop consumers ###
+    op.drop_constraint(op.f('fk_message_batches_consumer_id'), 'message_batches', type_='foreignkey')
+    op.drop_column('message_batches', 'consumer_id')
+    op.drop_table('consumers')
+    # ### end Alembic commands ###


### PR DESCRIPTION
This model is going to be used to identify the
senders/origin of message batches - we decided to
make it have a more specific name than Client.

I've just dropped the Client table rather than
renaming, as we do not have any remote/production
data in it yet and I'm making a few changes to
columns anyway:

Updating the `key` to be a unique field, as this
will be the human readable string sent by the
service to identify requests. And removing the
`name` and `description` fields until we think we
might need them.

<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
