### PR TITLE
DTOSS-9044: Require Consumer Key for MessageBatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ This endpoint is used to send a batch of messages. It accepts a JSON payload con
 - **Headers:**
   - Authorization: `Bearer <CLIENT_TOKEN>`
   - Content-Type: application/json
+  - X-Consumer-Key: `some-consumer`
 - **Body (JSON):**
 
   ```json

--- a/src/notify/app/models.py
+++ b/src/notify/app/models.py
@@ -38,6 +38,14 @@ class MessageStatuses(enum.Enum):
 
 
 # Tables
+class Consumer(Base):
+    __tablename__ = "consumers"
+
+    id = Column(Integer, primary_key=True)
+    key = Column(String, unique=True, nullable=False)
+    created_at = Column(TIMESTAMP, nullable=False, server_default=func.now())
+
+
 class MessageBatch(Base):
     __tablename__ = "message_batches"
 
@@ -51,6 +59,7 @@ class MessageBatch(Base):
         postgresql.ENUM(MessageBatchStatuses, values_callable=lambda x: [e.value for e in x]),
         default=MessageBatchStatuses.NOT_SENT,
     )
+    consumer_id = Column(Integer, ForeignKey("consumers.id"), nullable=False)
 
 
 class Message(Base):

--- a/src/notify/app/route_handlers/message.py
+++ b/src/notify/app/route_handlers/message.py
@@ -34,4 +34,4 @@ def bearer_token() -> str:
     return "invalid"
 
 def consumer_key() -> str | None:
-    return request.headers.get("X-Consumer-Key")
+    return request.headers.get(request_validator.CONSUMER_KEY)

--- a/src/notify/app/route_handlers/message.py
+++ b/src/notify/app/route_handlers/message.py
@@ -4,8 +4,15 @@ import app.services.message_batch_dispatcher as message_batch_dispatcher
 
 
 def batch():
-    if not request.headers.get("Authorization"):
-        return {"status": "failed", "error": "Authorization header not present"}, 401
+    valid_headers, headers_error_message = request_validator.verify_batch_headers(dict(request.headers))
+
+    if not valid_headers:
+        return {"status": "failed", "error": headers_error_message}, 401
+
+    consumer, consumer_error_message = request_validator.verify_consumer(consumer_key())
+
+    if not consumer:
+        return {"status": "failed", "error": consumer_error_message}, 401
 
     json_data = request.json or {}
 
@@ -14,7 +21,7 @@ def batch():
     if not valid_body:
         return {"status": "failed", "error": error_message}, 422
 
-    status_code, response = message_batch_dispatcher.dispatch(json_data, bearer_token())
+    status_code, response = message_batch_dispatcher.dispatch(json_data, consumer.id, bearer_token())
     status = "success" if status_code == 201 else "failed"
 
     return {"status": status, "response": response}, status_code
@@ -25,3 +32,6 @@ def bearer_token() -> str:
     if header_value and header_value.startswith("Bearer "):
         return header_value.split(" ")[1]
     return "invalid"
+
+def consumer_key() -> str | None:
+    return request.headers.get("X-Consumer-Key")

--- a/src/notify/app/services/message_batch_dispatcher.py
+++ b/src/notify/app/services/message_batch_dispatcher.py
@@ -7,7 +7,7 @@ import requests
 import uuid
 
 
-def dispatch(body: dict, bearer_token: str | None = None) -> tuple[int, str]:
+def dispatch(body: dict, consumer_id: int, bearer_token: str | None = None) -> tuple[int, str]:
     if not bearer_token:
         bearer_token = access_token.get_token()
 
@@ -16,7 +16,7 @@ def dispatch(body: dict, bearer_token: str | None = None) -> tuple[int, str]:
 
     success = response.status_code == 201
     status = models.MessageBatchStatuses.SENT if success else models.MessageBatchStatuses.FAILED
-    message_batch_recorder.save_batch(body, response.json(), status)
+    message_batch_recorder.save_batch(body, response.json(), status, consumer_id)
 
     return response.status_code, response.json()
 

--- a/src/notify/app/validators/request_validator.py
+++ b/src/notify/app/validators/request_validator.py
@@ -21,6 +21,15 @@ def verify_headers(headers: dict, api_key: str) -> tuple[bool, str]:
 
     return True, ""
 
+def verify_batch_headers(headers: dict) -> tuple[bool, str]:
+    lc_headers = header_keys_to_lower(headers)
+    if lc_headers.get('authorization') is None:
+        return False, "Authorization header not present"
+    if lc_headers.get('x-consumer-key') is None:
+        return False, "Consumer Key header not present"
+
+    return True, ""
+
 
 def verify_signature(headers: dict, body: dict, signature: str) -> bool:
     lc_headers = header_keys_to_lower(headers)

--- a/src/notify/app/validators/request_validator.py
+++ b/src/notify/app/validators/request_validator.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 
 API_KEY_HEADER_NAME = 'x-api-key'
 SIGNATURE_HEADER_NAME = 'x-hmac-sha256-signature'
+CONSUMER_KEY = 'x-consumer-key'
 
 
 def verify_headers(headers: dict, api_key: str) -> tuple[bool, str]:
@@ -28,7 +29,7 @@ def verify_batch_headers(headers: dict) -> tuple[bool, str]:
     lc_headers = header_keys_to_lower(headers)
     if lc_headers.get('authorization') is None:
         return False, "Authorization header not present"
-    if lc_headers.get('x-consumer-key') is None:
+    if lc_headers.get(CONSUMER_KEY) is None:
         return False, "Consumer Key header not present"
 
     return True, ""

--- a/src/notify/app/validators/request_validator.py
+++ b/src/notify/app/validators/request_validator.py
@@ -1,8 +1,11 @@
+from app.models import Consumer
+import app.utils.database as database
 import hmac
 import json
 import os
 import app.validators.schema_validator as schema_validator
 import app.utils.hmac_signature as hmac_signature
+from sqlalchemy.orm import Session
 
 API_KEY_HEADER_NAME = 'x-api-key'
 SIGNATURE_HEADER_NAME = 'x-hmac-sha256-signature'
@@ -30,6 +33,13 @@ def verify_batch_headers(headers: dict) -> tuple[bool, str]:
 
     return True, ""
 
+def verify_consumer(consumer_key: str | None) -> tuple[Consumer, str] | tuple[None, str]:
+    consumer = Session(database.engine()).query(Consumer).filter_by(key=consumer_key).one_or_none()
+
+    if not consumer:
+        return None, "Consumer not valid"
+
+    return consumer, ""
 
 def verify_signature(headers: dict, body: dict, signature: str) -> bool:
     lc_headers = header_keys_to_lower(headers)

--- a/src/notify/migrations/versions/891274ce0411_renaming_client_model_to_consumer.py
+++ b/src/notify/migrations/versions/891274ce0411_renaming_client_model_to_consumer.py
@@ -1,0 +1,63 @@
+"""Renaming Client model to Consumer
+
+Revision ID: 891274ce0411
+Revises: e9702592451c
+Create Date: 2025-07-15 11:33:33.061927
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '891274ce0411'
+down_revision: Union[str, None] = 'e9702592451c'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ### create consumers table ###
+    op.create_table('consumers',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('key', sa.String(), nullable=False),
+    sa.Column('created_at', sa.TIMESTAMP(), server_default=sa.text('now()'), nullable=False),
+    sa.PrimaryKeyConstraint('id'),
+    sa.UniqueConstraint('key')
+    )
+    # ### add foreign key to message_batches ###
+    op.add_column('message_batches',
+                sa.Column('consumer_id', sa.Integer(), nullable=False))
+    op.create_foreign_key(
+        'fk_message_batches_consumer_id',
+        'message_batches',
+        'consumers',
+        ['consumer_id'],
+        ['id'],
+        ondelete='CASCADE'
+    )
+    # ### drop clients ###
+    op.drop_constraint(op.f('fk_message_batches_client_id'), 'message_batches', type_='foreignkey')
+    op.drop_column('message_batches', 'client_id')
+    op.drop_table('clients')
+    # ### end Alembic commands ###
+
+
+def downgrade() -> None:
+    # ### Add client back ###
+    op.create_table('clients',
+    sa.Column('id', sa.INTEGER(), autoincrement=True, nullable=False),
+    sa.Column('name', sa.String(), autoincrement=False, nullable=True),
+    sa.Column('description', sa.String(), autoincrement=False, nullable=True),
+    sa.Column('key', sa.UUID(), autoincrement=False, nullable=False),
+    sa.Column('created_at', sa.TIMESTAMP(), server_default=sa.text('now()'), autoincrement=False, nullable=False),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.add_column('message_batches', sa.Column('client_id', sa.INTEGER(), autoincrement=False, nullable=True))
+    op.create_foreign_key(op.f('fk_message_batches_client_id'), 'message_batches', 'clients', ['client_id'], ['id'], ondelete='CASCADE')
+    # ### Drop consumers ###
+    op.drop_constraint(op.f('fk_message_batches_consumer_id'), 'message_batches', type_='foreignkey')
+    op.drop_column('message_batches', 'consumer_id')
+    op.drop_table('consumers')
+    # ### end Alembic commands ###

--- a/tests/end_to_end/runner/helpers.py
+++ b/tests/end_to_end/runner/helpers.py
@@ -1,3 +1,4 @@
+from app.validators.request_validator import CONSUMER_KEY
 import dotenv
 import os
 import requests
@@ -10,6 +11,7 @@ def get_status_endpoint(batch_reference):
         "Content-Type": "application/json",
         "x-api-key": os.getenv('CLIENT_API_KEY'),
         "x-hmac-sha256-signature": "anything",
+        CONSUMER_KEY: "some-consumer",
     }
 
     return requests.get(
@@ -22,7 +24,7 @@ def post_message_batch_endpoint(message_batch_post_body):
     headers = {
         "Authorization": "Bearer client_token",
         "Content-Type": "application/json",
-        "X-Consumer-Key": "some-consumer",
+        CONSUMER_KEY: "some-consumer",
     }
 
     return requests.post(

--- a/tests/end_to_end/runner/helpers.py
+++ b/tests/end_to_end/runner/helpers.py
@@ -22,6 +22,7 @@ def post_message_batch_endpoint(message_batch_post_body):
     headers = {
         "Authorization": "Bearer client_token",
         "Content-Type": "application/json",
+        "X-Consumer-Key": "some-consumer",
     }
 
     return requests.post(

--- a/tests/end_to_end/runner/helpers.py
+++ b/tests/end_to_end/runner/helpers.py
@@ -1,6 +1,4 @@
-import azure.storage.blob
 import dotenv
-import logging
 import os
 import requests
 

--- a/tests/end_to_end/runner/test_post_to_message_batch_endpoint.py
+++ b/tests/end_to_end/runner/test_post_to_message_batch_endpoint.py
@@ -3,6 +3,7 @@ import app.utils.database as database
 import app.utils.hmac_signature as hmac_signature
 import dotenv
 from .helpers import post_message_batch_endpoint, get_status_endpoint
+import logging
 from pytest_steps.steps import test_steps
 from sqlalchemy.sql.expression import select
 from sqlalchemy.orm import Session
@@ -16,7 +17,7 @@ dotenv.load_dotenv()
     'status_create_endpoint_saves_to_database',
     'statuses_endpoint_returns_correct_statuses'
 )
-def test_post_message_batch_end_to_end(message_batch_post_body, message_batch_post_response):
+def test_post_message_batch_end_to_end(message_batch_post_body, message_batch_post_response, consumer):
     response = post_message_batch_endpoint(message_batch_post_body)
 
     # Wait for the callbacks to be received and saved to the database

--- a/tests/end_to_end/runner/test_post_to_message_batch_endpoint.py
+++ b/tests/end_to_end/runner/test_post_to_message_batch_endpoint.py
@@ -3,7 +3,7 @@ import app.utils.database as database
 import app.utils.hmac_signature as hmac_signature
 import dotenv
 from .helpers import post_message_batch_endpoint, get_status_endpoint
-from pytest_steps import test_steps
+from pytest_steps.steps import test_steps
 from sqlalchemy.sql.expression import select
 from sqlalchemy.orm import Session
 import time

--- a/tests/integration/notify/app/route_handlers/test_message_batch.py
+++ b/tests/integration/notify/app/route_handlers/test_message_batch.py
@@ -1,4 +1,5 @@
 from app import create_app
+from app.validators.request_validator import CONSUMER_KEY
 import pytest
 import requests_mock
 
@@ -20,7 +21,7 @@ def test_message_batch_succeeds(setup, client, message_batch_post_body, message_
 
     headers = {
         "Authorization": "Bearer client_token",
-        "X-Consumer-Key": consumer.key
+        CONSUMER_KEY: consumer.key
     }
 
     with requests_mock.Mocker() as rm:
@@ -41,7 +42,7 @@ def test_message_batch_preserves_auth_header(setup, client, message_batch_post_b
 
     headers = {
         "Authorization": "Bearer client_token",
-        "X-Consumer-Key": "some-consumer"
+        CONSUMER_KEY: "some-consumer"
     }
 
     with requests_mock.Mocker() as rm:
@@ -61,7 +62,7 @@ def test_message_batch_fails_with_invalid_auth_header(setup, client, message_bat
     """Test that invalid Bearer token fails authentication."""
     headers = {
         "Authorization": "some_invalid_value",
-        "X-Consumer-Key": "some-consumer"
+        CONSUMER_KEY: "some-consumer"
     }
 
     with requests_mock.Mocker() as rm:
@@ -80,7 +81,7 @@ def test_message_batch_fails_with_invalid_auth_header(setup, client, message_bat
 def test_message_batch_fails_with_missing_auth_header(setup, client, message_batch_post_body):
     """Test that missing auth header fails authentication."""
     headers = {
-        "X-Consumer-Key": "some-consumer"
+        CONSUMER_KEY: "some-consumer"
     }
 
     with requests_mock.Mocker() as rm:
@@ -110,7 +111,7 @@ def test_message_batch_fails_with_nonexistent_consumer_header(setup, client, mes
     """Test that missing auth header fails authentication."""
     headers = {
         "Authorization": "Bearer client_token",
-        "X-Consumer-Key": "invalid-consumer"
+        CONSUMER_KEY: "invalid-consumer"
     }
 
     response = client.post('/api/message/batch', json=message_batch_post_body, headers=headers)
@@ -124,7 +125,7 @@ def test_message_batch_fails_with_invalid_post_body(setup, client, message_batch
 
     headers = {
         "Authorization": "Bearer client_token",
-        "X-Consumer-Key": "some-consumer"
+        CONSUMER_KEY: "some-consumer"
     }
 
     response = client.post('/api/message/batch', json=message_batch_post_body, headers=headers)

--- a/tests/unit/notify/app/services/test_status_reporter.py
+++ b/tests/unit/notify/app/services/test_status_reporter.py
@@ -98,9 +98,9 @@ def test_statuses_for_multiple_criteria_are_found(channel_status_post_body):
     assert attrs["supplierStatus"] == "read"
 
 
-def test_statuses_for_nhs_number_are_found(channel_status_post_body, message_batch_post_body, message_batch_post_response):
+def test_statuses_for_nhs_number_are_found(channel_status_post_body, message_batch_post_body, message_batch_post_response, consumer):
     """Test searching channel status records by NHS number"""
-    message_batch_recorder.save_batch(message_batch_post_body, message_batch_post_response, models.MessageBatchStatuses.SENT)
+    message_batch_recorder.save_batch(message_batch_post_body, message_batch_post_response, models.MessageBatchStatuses.SENT, consumer.id)
     status_recorder.save_statuses(channel_status_post_body)
 
     query_params = {"nhsNumber": "4010232137"}
@@ -109,9 +109,9 @@ def test_statuses_for_nhs_number_are_found(channel_status_post_body, message_bat
     assert len(statuses) == 1
 
 
-def test_statuses_for_batch_reference_are_found(message_batch_post_body, message_batch_post_response, channel_status_post_body):
+def test_statuses_for_batch_reference_are_found(message_batch_post_body, message_batch_post_response, channel_status_post_body, consumer):
     """Test searching channel status records by batch reference"""
-    message_batch_recorder.save_batch(message_batch_post_body, message_batch_post_response, models.MessageBatchStatuses.SENT)
+    message_batch_recorder.save_batch(message_batch_post_body, message_batch_post_response, models.MessageBatchStatuses.SENT, consumer.id)
     status_recorder.save_statuses(channel_status_post_body)
 
     another_message_batch_reference = str(uuid.uuid4())
@@ -120,7 +120,7 @@ def test_statuses_for_batch_reference_are_found(message_batch_post_body, message
     another_message_batch_post_response = message_batch_post_response.copy()
     another_message_batch_post_response["data"]["attributes"]["messages"][0]["id"] = "another_message_id"
     another_message_batch_post_response["data"]["attributes"]["messageBatchReference"] = another_message_batch_reference
-    message_batch_recorder.save_batch(another_message_batch_post_body, another_message_batch_post_response, models.MessageBatchStatuses.SENT)
+    message_batch_recorder.save_batch(another_message_batch_post_body, another_message_batch_post_response, models.MessageBatchStatuses.SENT, consumer.id)
 
     another_channel_status_post_body = channel_status_post_body.copy()
     another_channel_status_post_body["data"][0]["attributes"]["messageId"] = another_message_batch_post_response["data"]["attributes"]["messages"][0]["id"]

--- a/tests/unit/notify/app/validators/test_request_validator.py
+++ b/tests/unit/notify/app/validators/test_request_validator.py
@@ -85,3 +85,23 @@ def test_verify_batch_headers_valid(setup):
         "X-Consumer-Key": 'some-key'
     }
     assert request_validator.verify_batch_headers(headers)
+
+
+def test_verify_consumer_not_found(setup):
+    """Test that a Consumer is found with given consumer_key"""
+    returned_consumer, error_message = request_validator.verify_consumer("not-a-consumer")
+    assert returned_consumer == None
+    assert error_message == "Consumer not valid"
+
+
+def test_verify_consumer_no_key(setup):
+    """Test that a Consumer is found with given consumer_key"""
+    returned_consumer, error_message = request_validator.verify_consumer(None)
+    assert returned_consumer == None
+    assert error_message == "Consumer not valid"
+
+
+def test_verify_consumer_found(setup, consumer):
+    """Test that a Consumer is found with given consumer_key"""
+    returned_consumer, _ = request_validator.verify_consumer("some-consumer")
+    assert returned_consumer.id == consumer.id

--- a/tests/unit/notify/app/validators/test_request_validator.py
+++ b/tests/unit/notify/app/validators/test_request_validator.py
@@ -59,3 +59,29 @@ def test_verify_headers_invalid_api_key(setup):
     """Test that an invalid API key fails verification."""
     headers = {request_validator.API_KEY_HEADER_NAME: 'invalid_api_key'}
     assert request_validator.verify_headers(headers, 'api_key') == (False, 'Invalid API key')
+
+def test_verify_batch_headers_missing_all(setup):
+    """Test that missing all headers for batch requests fails verification."""
+    headers = {}
+    assert request_validator.verify_batch_headers(headers) == (False, 'Authorization header not present')
+
+
+def test_verify_batch_headers_missing_authorization(setup):
+    """Test that missing Authorization fails verification."""
+    headers = {"X-Consumer-Key": 'some-key'}
+    assert request_validator.verify_batch_headers(headers) == (False, 'Authorization header not present')
+
+
+def test_verify_batch_headers_missing_consumer_key(setup):
+    """Test that missing consumer key fails verification."""
+    headers = {"Authorization": 'auth'}
+    assert request_validator.verify_batch_headers(headers) == (False, 'Consumer Key header not present')
+
+
+def test_verify_batch_headers_valid(setup):
+    """Test that valid API key and signature headers pass verification."""
+    headers = {
+        "Authorization": 'auth',
+        "X-Consumer-Key": 'some-key'
+    }
+    assert request_validator.verify_batch_headers(headers)

--- a/tests/unit/notify/app/validators/test_request_validator.py
+++ b/tests/unit/notify/app/validators/test_request_validator.py
@@ -68,7 +68,7 @@ def test_verify_batch_headers_missing_all(setup):
 
 def test_verify_batch_headers_missing_authorization(setup):
     """Test that missing Authorization fails verification."""
-    headers = {"X-Consumer-Key": 'some-key'}
+    headers = {request_validator.CONSUMER_KEY: 'some-key'}
     assert request_validator.verify_batch_headers(headers) == (False, 'Authorization header not present')
 
 
@@ -82,7 +82,7 @@ def test_verify_batch_headers_valid(setup):
     """Test that valid API key and signature headers pass verification."""
     headers = {
         "Authorization": 'auth',
-        "X-Consumer-Key": 'some-key'
+        request_validator.CONSUMER_KEY: 'some-key'
     }
     assert request_validator.verify_batch_headers(headers)
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
https://nhsd-jira.digital.nhs.uk/browse/DTOSS-9044

This is the first part of the process to introduce Consumer identification to MessageBatches - Introducing a required key in the headers to link an existing Consumer with a MessageBatch, and making the Consumer required in order to POST a MessageBatch. Part 2 of this ticket will introduce sending the Consumer key in headers when GETing Statuses.

In this PR we are:
* Assuming the consumer has awareness of a secret `consumer-key` to pass in the header, and we've pre-loaded the Consumer into our database
* Checking the Consumer exists in the `message_batch_dispatcher` and if it doesn't return 401
* If it does exist, then we add it as a fk onto the MessageBatch in our database 

<!-- Describe your changes in detail. -->

## Context

Some more context on design decisions made here https://screening-discovery.slack.com/archives/C07QHFSV79U/p1752590185296169?thread_ts=1752570047.619469&cid=C07QHFSV79U

* we'll have a pre-existing hardcoded table of Consumers that has no user-facing element
* Consumer will send an identifying key in headers for both POST and GET requests (they will get this from their env variables)
* If a Consumer Key is not provided, they cannot POST batches (as a Consumer is a required foreign key on MessageBatches)
* If a Consumer Key is not provided, they cannot GET statuses (As we will be filtering batches by consumer)

Still open to name/field name changes. 

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
