### PR TITLE
quick fix to ignore broken nhs-notify-api container for CI

### DIFF
--- a/.github/workflows/cicd-1-pull-request.yaml
+++ b/.github/workflows/cicd-1-pull-request.yaml
@@ -100,7 +100,7 @@ jobs:
     if: needs.metadata.outputs.does_pull_request_exist == 'true' || github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened'))
     with:
       docker_compose_file: ./compose.yml
-      excluded_containers_csv_list: azurite,azurite-setup,db,end-to-end-tests,nhs-notify-api-stub
+      excluded_containers_csv_list: azurite,azurite-setup,db,end-to-end-tests,nhs-notify-api-stub,nhs-notify-api
       environment_tag: ${{ needs.metadata.outputs.environment_tag }}
       function_app_source_code_path: src
       project_name: communication-management


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

this container is currently erroring during CI
process as the name cannot be found. Pending a
more sustainable fix as per this chat [1] this
will allow PRs to go green for now.

[1] https://screening-discovery.slack.com/archives/C07QHFSV79U/p1752595562397039?thread_ts=1752584013.241669&cid=C07QHFSV79U

## Context

* Ignores the `nhs-notify-api` container for PR CI.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
