### PR TITLE
DTOSS-10246: Consisten request headers for Consumer end points

### DIFF
--- a/src/notify/app/route_handlers/message.py
+++ b/src/notify/app/route_handlers/message.py
@@ -1,10 +1,11 @@
 from flask import request
 import app.validators.request_validator as request_validator
 import app.services.message_batch_dispatcher as message_batch_dispatcher
+import os
 
 
 def batch():
-    valid_headers, headers_error_message = request_validator.verify_batch_headers(dict(request.headers))
+    valid_headers, headers_error_message = request_validator.verify_headers_for_consumers(dict(request.headers), str(os.getenv("CLIENT_API_KEY")))
 
     if not valid_headers:
         return {"status": "failed", "error": headers_error_message}, 401

--- a/src/notify/app/route_handlers/status.py
+++ b/src/notify/app/route_handlers/status.py
@@ -30,7 +30,7 @@ def create():
 
 
 def get():
-    valid_headers, error_message = request_validator.verify_get_statuses_headers(
+    valid_headers, error_message = request_validator.verify_headers_for_consumers(
         dict(request.headers), str(os.getenv("CLIENT_API_KEY"))
     )
 

--- a/src/notify/app/validators/request_validator.py
+++ b/src/notify/app/validators/request_validator.py
@@ -8,6 +8,7 @@ import app.utils.hmac_signature as hmac_signature
 from sqlalchemy.orm import Session
 
 API_KEY_HEADER_NAME = 'x-api-key'
+AUTHORIZATION_HEADER_NAME = 'authorization'
 SIGNATURE_HEADER_NAME = 'x-hmac-sha256-signature'
 CONSUMER_KEY_NAME = 'x-consumer-key'
 
@@ -49,6 +50,20 @@ def verify_batch_headers(headers: dict) -> tuple[bool, str]:
         return False, "Authorization header not present"
     if lc_headers.get(CONSUMER_KEY_NAME) is None:
         return False, "Consumer Key header not present"
+
+    return True, ""
+
+
+def verify_headers_for_consumers(headers: dict, api_key: str) -> tuple[bool, str]:
+    lc_headers = header_keys_to_lower(headers)
+    if lc_headers.get(AUTHORIZATION_HEADER_NAME) is None:
+        return False, "Missing Authorization header"
+    if lc_headers.get(API_KEY_HEADER_NAME) is None:
+        return False, "Missing API key header"
+    if lc_headers.get(API_KEY_HEADER_NAME) != api_key:
+        return False, "Invalid API key"
+    if lc_headers.get(CONSUMER_KEY_NAME) is None:
+        return False, "Missing Consumer key header"
 
     return True, ""
 

--- a/src/notify/app/validators/request_validator.py
+++ b/src/notify/app/validators/request_validator.py
@@ -27,16 +27,6 @@ def verify_headers(headers: dict, api_key: str) -> tuple[bool, str]:
     return True, ""
 
 
-def verify_batch_headers(headers: dict) -> tuple[bool, str]:
-    lc_headers = header_keys_to_lower(headers)
-    if lc_headers.get('authorization') is None:
-        return False, "Authorization header not present"
-    if lc_headers.get(CONSUMER_KEY_NAME) is None:
-        return False, "Consumer Key header not present"
-
-    return True, ""
-
-
 def verify_headers_for_consumers(headers: dict, api_key: str) -> tuple[bool, str]:
     lc_headers = header_keys_to_lower(headers)
     if lc_headers.get(AUTHORIZATION_HEADER_NAME) is None:

--- a/src/notify/app/validators/request_validator.py
+++ b/src/notify/app/validators/request_validator.py
@@ -27,23 +27,6 @@ def verify_headers(headers: dict, api_key: str) -> tuple[bool, str]:
     return True, ""
 
 
-def verify_get_statuses_headers(headers: dict, api_key: str) -> tuple[bool, str]:
-    lc_headers = header_keys_to_lower(headers)
-    if lc_headers.get(API_KEY_HEADER_NAME) is None:
-        return False, "Missing API key header"
-
-    if lc_headers.get(API_KEY_HEADER_NAME) != api_key:
-        return False, "Invalid API key"
-
-    if lc_headers.get(SIGNATURE_HEADER_NAME) is None:
-        return False, "Missing signature header"
-
-    if lc_headers.get(CONSUMER_KEY_NAME) is None:
-        return False, "Missing Consumer key header"
-
-    return True, ""
-
-
 def verify_batch_headers(headers: dict) -> tuple[bool, str]:
     lc_headers = header_keys_to_lower(headers)
     if lc_headers.get('authorization') is None:

--- a/tests/end_to_end/runner/helpers.py
+++ b/tests/end_to_end/runner/helpers.py
@@ -1,4 +1,4 @@
-from app.validators.request_validator import CONSUMER_KEY_NAME
+from app.validators.request_validator import API_KEY_HEADER_NAME, CONSUMER_KEY_NAME
 import dotenv
 import os
 import requests
@@ -8,6 +8,7 @@ dotenv.load_dotenv()
 
 def get_status_endpoint(batch_reference):
     headers = {
+        "Authorization": "Bearer client_token",
         "Content-Type": "application/json",
         "x-api-key": os.getenv('CLIENT_API_KEY'),
         "x-hmac-sha256-signature": "anything",
@@ -25,6 +26,7 @@ def post_message_batch_endpoint(message_batch_post_body):
         "Authorization": "Bearer client_token",
         "Content-Type": "application/json",
         CONSUMER_KEY_NAME: "some-consumer",
+        API_KEY_HEADER_NAME: os.getenv('CLIENT_API_KEY'),
     }
 
     return requests.post(

--- a/tests/integration/notify/app/route_handlers/test_get_statuses_endpoint.py
+++ b/tests/integration/notify/app/route_handlers/test_get_statuses_endpoint.py
@@ -1,6 +1,6 @@
 from app import create_app
 import app.services.status_recorder as status_recorder
-from app.validators.request_validator import API_KEY_HEADER_NAME, SIGNATURE_HEADER_NAME, CONSUMER_KEY_NAME
+from app.validators.request_validator import API_KEY_HEADER_NAME, AUTHORIZATION_HEADER_NAME, CONSUMER_KEY_NAME
 import pytest
 
 
@@ -19,17 +19,37 @@ def client():
 
 
 def test_get_statuses_request_validation_fails_on_api_key(setup, client, message_status_post_body):
-    """Test that invalid request header values fail HMAC signature validation."""
-    headers = {API_KEY_HEADER_NAME: "not_the_api_key", SIGNATURE_HEADER_NAME: "signature"}
+    """Test that invalid request header values fails on invalid api key validation."""
+    headers = {
+        AUTHORIZATION_HEADER_NAME: 'bearer auth',
+        API_KEY_HEADER_NAME: "not_the_api_key",
+    }
 
     response = client.get('/api/statuses', headers=headers)
 
     assert response.status_code == 401
     assert response.get_json() == {"status": "Invalid API key"}
 
+
+def test_get_statuses_request_validation_fails_on_missing_auth(setup, client, message_status_post_body):
+    """Test that invalid request header values fails on invalid api key validation."""
+    headers = {
+        API_KEY_HEADER_NAME: "api_key",
+    }
+
+    response = client.get('/api/statuses', headers=headers)
+
+    assert response.status_code == 401
+    assert response.get_json() == {
+        "status": "Missing Authorization header"}
+
+
 def test_get_statuses_request_validation_fails_on_missing_consumer(setup, client, message_status_post_body):
-    """Test that invalid request header values fail HMAC signature validation."""
-    headers = {API_KEY_HEADER_NAME: "api_key", SIGNATURE_HEADER_NAME: "signature"}
+    """Test that invalid request header values fail when Consumer missing."""
+    headers = {
+        AUTHORIZATION_HEADER_NAME: 'bearer auth',
+        API_KEY_HEADER_NAME: "api_key",
+    }
 
     response = client.get('/api/statuses', headers=headers)
 
@@ -38,10 +58,10 @@ def test_get_statuses_request_validation_fails_on_missing_consumer(setup, client
 
 
 def test_get_statuses_request_validation_fails_on_invalid_consumer(setup, client, message_status_post_body):
-    """Test that invalid request header values fail signature validation."""
+    """Test that invalid request header values fail on invalid consumer."""
     headers = {
         API_KEY_HEADER_NAME: "api_key",
-        SIGNATURE_HEADER_NAME: "signature",
+        AUTHORIZATION_HEADER_NAME: 'bearer auth',
         CONSUMER_KEY_NAME: "not-a-consumer"
     }
 
@@ -69,7 +89,7 @@ def test_get_statuses(setup, client, channel_status_post_body, message_batch_pos
 
     headers = {
         API_KEY_HEADER_NAME: "api_key",
-        SIGNATURE_HEADER_NAME: "signature",
+        AUTHORIZATION_HEADER_NAME: 'bearer auth',
         CONSUMER_KEY_NAME: "some-consumer",
     }
 

--- a/tests/unit/notify/app/validators/test_request_validator.py
+++ b/tests/unit/notify/app/validators/test_request_validator.py
@@ -60,48 +60,6 @@ def test_verify_headers_invalid_api_key(setup):
     headers = {request_validator.API_KEY_HEADER_NAME: 'invalid_api_key'}
     assert request_validator.verify_headers(headers, 'api_key') == (False, 'Invalid API key')
 
-def test_verify_get_statuses_headers_missing_all(setup):
-    """Test that missing all headers fails verification."""
-    headers = {}
-    assert request_validator.verify_get_statuses_headers(headers, 'api_key') == (False, 'Missing API key header')
-
-
-def test_verify_get_statuses_headers_missing_api_key(setup):
-    """Test that missing API key header fails verification."""
-    headers = {request_validator.SIGNATURE_HEADER_NAME: 'signature'}
-    assert request_validator.verify_get_statuses_headers(headers, 'api_key') == (False, 'Missing API key header')
-
-
-def test_verify_get_statuses_headers_missing_signature(setup):
-    """Test that missing signature header fails verification."""
-    headers = {request_validator.API_KEY_HEADER_NAME: 'api_key'}
-    assert request_validator.verify_get_statuses_headers(headers, 'api_key') == (False, 'Missing signature header')
-
-
-def test_verify_get_statuses_headers_missing_consumer(setup):
-    """Test that missing consumer header fails verification."""
-    headers = {
-        request_validator.API_KEY_HEADER_NAME: 'api_key',
-        request_validator.SIGNATURE_HEADER_NAME: 'signature',
-    }
-    assert request_validator.verify_get_statuses_headers(headers, 'api_key') == (False, 'Missing Consumer key header')
-
-
-def test_verify_get_statuses_headers_valid(setup):
-    """Test that valid API key and signature headers pass verification."""
-    headers = {
-        request_validator.API_KEY_HEADER_NAME: 'api_key',
-        request_validator.SIGNATURE_HEADER_NAME: 'signature',
-        request_validator.CONSUMER_KEY_NAME: 'something'
-    }
-    assert request_validator.verify_get_statuses_headers(headers, 'api_key') == (True, '')
-
-
-def test_verify_get_statuses_headers_invalid_api_key(setup):
-    """Test that an invalid API key fails verification."""
-    headers = {request_validator.API_KEY_HEADER_NAME: 'invalid_api_key'}
-    assert request_validator.verify_get_statuses_headers(headers, 'api_key') == (False, 'Invalid API key')
-
 
 def test_verify_batch_headers_missing_all(setup):
     """Test that missing all headers for batch requests fails verification."""

--- a/tests/unit/notify/app/validators/test_request_validator.py
+++ b/tests/unit/notify/app/validators/test_request_validator.py
@@ -130,6 +130,58 @@ def test_verify_batch_headers_valid(setup):
     assert request_validator.verify_batch_headers(headers)
 
 
+def test_verify_get_headers_for_missing_auth(setup):
+    """Test that valid headers pass verification."""
+    headers = {
+        request_validator.API_KEY_HEADER_NAME: 'api_key',
+        request_validator.CONSUMER_KEY_NAME: 'some-key'
+    }
+    assert request_validator.verify_headers_for_consumers(
+        headers, 'api_key') == (False, "Missing Authorization header")
+
+
+def test_verify_headers_for_consumers_invalid_api_key(setup):
+    """Test that valid headers pass verification."""
+    headers = {
+        "Authorization": 'auth',
+        request_validator.API_KEY_HEADER_NAME: 'wrong',
+        request_validator.CONSUMER_KEY_NAME: 'some-key'
+    }
+    assert request_validator.verify_headers_for_consumers(
+        headers, 'api_key') == (False, "Invalid API key")
+
+
+def test_verify_headers_for_consumers_missing_api_key(setup):
+    """Test that valid headers pass verification."""
+    headers = {
+        "Authorization": 'auth',
+        request_validator.CONSUMER_KEY_NAME: 'some-key'
+    }
+    assert request_validator.verify_headers_for_consumers(
+        headers, 'api_key') == (False, "Missing API key header")
+
+
+def test_verify_headers_for_consumers_missing_consumer(setup):
+    """Test that valid headers pass verification."""
+    headers = {
+        "Authorization": 'auth',
+        request_validator.API_KEY_HEADER_NAME: 'api_key',
+    }
+    assert request_validator.verify_headers_for_consumers(
+        headers, 'api_key') == (False, "Missing Consumer key header")
+
+
+def test_verify_headers_for_consumers_valid(setup):
+    """Test that valid headers pass verification."""
+    headers = {
+        "Authorization": 'auth',
+        request_validator.API_KEY_HEADER_NAME: 'api_key',
+        request_validator.CONSUMER_KEY_NAME: 'some-key'
+    }
+    assert request_validator.verify_headers_for_consumers(
+        headers, 'api_key') == (True, "")
+
+
 def test_verify_consumer_not_found(setup):
     """Test that a Consumer is found with given consumer_key"""
     returned_consumer, error_message = request_validator.verify_consumer("not-a-consumer")

--- a/tests/unit/notify/app/validators/test_request_validator.py
+++ b/tests/unit/notify/app/validators/test_request_validator.py
@@ -61,33 +61,6 @@ def test_verify_headers_invalid_api_key(setup):
     assert request_validator.verify_headers(headers, 'api_key') == (False, 'Invalid API key')
 
 
-def test_verify_batch_headers_missing_all(setup):
-    """Test that missing all headers for batch requests fails verification."""
-    headers = {}
-    assert request_validator.verify_batch_headers(headers) == (False, 'Authorization header not present')
-
-
-def test_verify_batch_headers_missing_authorization(setup):
-    """Test that missing Authorization fails verification."""
-    headers = {request_validator.CONSUMER_KEY_NAME: 'some-key'}
-    assert request_validator.verify_batch_headers(headers) == (False, 'Authorization header not present')
-
-
-def test_verify_batch_headers_missing_consumer_key(setup):
-    """Test that missing consumer key fails verification."""
-    headers = {"Authorization": 'auth'}
-    assert request_validator.verify_batch_headers(headers) == (False, 'Consumer Key header not present')
-
-
-def test_verify_batch_headers_valid(setup):
-    """Test that valid API key and signature headers pass verification."""
-    headers = {
-        "Authorization": 'auth',
-        request_validator.CONSUMER_KEY_NAME: 'some-key'
-    }
-    assert request_validator.verify_batch_headers(headers)
-
-
 def test_verify_get_headers_for_missing_auth(setup):
     """Test that valid headers pass verification."""
     headers = {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

https://nhsd-jira.digital.nhs.uk/browse/DTOSS-10246

The GET and POST request header validation should be the same,[as set here](https://github.com/NHSDigital/dtos-communication-management/blob/main/src/notify/app/validators/request_validator.py#L55-L56) , on any endpoint called by a Consumer (see below), so that we can validate requests to the API. 

As noted on this PR https://github.com/NHSDigital/dtos-communication-management/pull/291#discussion_r2222319597 

We should expect an Authorization header for any request that is not GET /healthcheck or POST /status/create ie both POST /message/batch and GET /statuses.

So for requests coming from Consumers we would check:

Authorization header is present
API key header is present
API key matches
Consumer key header is present
Consumer key matches

<!-- Describe your changes in detail. -->

Introduce shared method and use it on the batch and status endpoints used by a Consumer

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
