### PR TITLE
Use a context manager in test to ensure db connection is closed

### DIFF
--- a/tests/unit/notify/app/commands/test_create_consumer.py
+++ b/tests/unit/notify/app/commands/test_create_consumer.py
@@ -13,11 +13,12 @@ def runner():
 
 
 def test_creates_consumer_with_new_key(runner, teardown_consumer):
-    key = "some-consumer"
-    assert Session(database.engine()).query(exists().where(Consumer.key==key)).scalar() == False
-    result = runner.invoke(args=["create-consumer", key])
-    assert Session(database.engine()).query(exists().where(Consumer.key==key)).scalar() == True
-    assert f"Consumer with key '{key}' created" in result.output
+    with Session(database.engine()) as session:
+        key = "some-consumer"
+        assert session.query(exists().where(Consumer.key == key)).scalar() is False
+        result = runner.invoke(args=["create-consumer", key])
+        assert session.query(exists().where(Consumer.key == key)).scalar() is True
+        assert f"Consumer with key '{key}' created" in result.output
 
 
 def test_errors_with_existing_key(runner, consumer):


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

After pulling from main and running tests pytest stopped at the amended test.
Root cause was that db connections were left open by the `Session(database.engine())` calls.
We need to look into connection management in a future story and possibly think about a better pattern for managing db connections, ie pooling.

Weird this works fine on CI, perhaps the number of possible open connections is higher on the runner service?

<!-- Describe your changes in detail. -->

### Changes: 

Use `with Session(database.engine()) as session:` context manager in the unit test which was hanging up.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
