### PR TITLE
Clear cache when creating consumers

### DIFF
--- a/src/notify/app/commands/create_consumer.py
+++ b/src/notify/app/commands/create_consumer.py
@@ -1,4 +1,5 @@
 from app.models import Consumer
+from app.queries.consumer import fetch_all_cached
 import app.utils.database as database
 from flask.cli import with_appcontext
 import click
@@ -13,6 +14,7 @@ def _create_consumer(key) -> tuple[Consumer, None] | tuple[None, str]:
             consumer = Consumer(key=key)
             session.add(consumer)
             session.commit()
+            fetch_all_cached.cache_clear()
             print(f"Consumer with key '{consumer.key}' created")
             return (consumer, None)
     except IntegrityError as e:

--- a/tests/unit/notify/app/queries/test_consumer.py
+++ b/tests/unit/notify/app/queries/test_consumer.py
@@ -2,6 +2,12 @@ import app.queries.consumer as query
 from app.utils.database import engine
 from app.models import Consumer
 from sqlalchemy.orm import Session
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    query.fetch_all_cached.cache_clear()
 
 
 def test_fetch_from_cache():
@@ -23,8 +29,6 @@ def test_fetch_from_cache_with_unmatched_key():
 
 
 def test_indexed_by_key():
-    query.fetch_all_cached.cache_clear()
-
     consumer = Consumer(key="aaa123")
     another_consumer = Consumer(key="bbb456")
 
@@ -45,8 +49,6 @@ def test_indexed_by_key():
 
 
 def test_fetch_all_is_memoized():
-    query.fetch_all_cached.cache_clear()
-
     with Session(engine()) as session:
         session.add(Consumer(key="abc123"))
         session.commit()


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

## Context

We create Consumers via a Flask admin command. We also cache consumers in `app.queries.consumer.fetch_all_cached` and use this function to check consumer tokens in requests to the API.

This PR:

Clears the list of consumers cached by `fetch_all_cached` when we invoke the `create-consumer` admin command.
<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
